### PR TITLE
Clear residual Cursor references missed by the 0.9.2 port substitution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -139,7 +139,7 @@ Upstream pstack jumped from `0.1.0` → `0.9.2` between syncs. 30+ commits, incl
 
 ### `skills/arena/SKILL.md`
 
-- Default 4 runners: GPT/composer slugs → Claude family. Added cross-vendor-bridge note.
+- Default 3 runners: GPT/composer slugs → Claude family. Added cross-vendor-bridge note.
 
 ### `skills/architect/SKILL.md`
 

--- a/plugins/pstack/skills/automate-me/SKILL.md
+++ b/plugins/pstack/skills/automate-me/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 A guided flow for turning the user's working conventions into a skill agents will follow. The output is one `-mode` skill tailored to them (e.g. `jay-mode`, `priya-mode`).
 
-This skill orchestrates three others: an inline mining pass (see step 1), Cursor's built-in `plugin-dev:skill-development` (authoring), and the **unslop** skill (prose discipline). It sequences them; it doesn't replace them.
+This skill orchestrates three others: an inline mining pass (see step 1), the `plugin-dev:skill-development` skill (authoring), and the **unslop** skill (prose discipline). It sequences them; it doesn't replace them.
 
 ## Flow
 

--- a/plugins/pstack/skills/poteto-mode/SKILL.md
+++ b/plugins/pstack/skills/poteto-mode/SKILL.md
@@ -22,7 +22,7 @@ Remaining triggers:
 - Before commit → the **deslop** skill (`/deslop`).
 - Shipping UI / IDE / CLI → the driver skill (`run` for CLIs/TUIs, `verify` for UIs). Both ship as Claude Code built-ins. For bug fixes, reproduce first on the same surface yourself; hand to the user only under the narrow Bug fix step 1 exception.
 - After opening a PR → the **babysit** skill.
-- Bugbot or the agentic security review commented → skeptical posture. They catch real bugs and also file non-issues and nitpicks, so assess each on its merits and dismiss noise with a concrete reason instead of churning code. Triage fix / dismiss / ask via the **babysit** skill.
+- An automated PR-review bot or the agentic security review commented → skeptical posture. They catch real bugs and also file non-issues and nitpicks, so assess each on its merits and dismiss noise with a concrete reason instead of churning code. Triage fix / dismiss / ask via the **babysit** skill.
 - Broken skill mid-task → fix it in its own PR. Don't block. Don't silently work around it.
 - Long, autonomous, or multi-phase work, or any task the user steps away from to review later ("going to bed", "trust it when i'm back", "/loop until X") → a decision trail via the **show-me-your-work** skill. Commit it when stakes need an auditable record; keep it local otherwise.
 
@@ -120,6 +120,6 @@ A large or cross-cutting effort (a migration across many call sites, an ambitiou
 - **Eval.** Testing how a skill, structure, or prompt change affects agent behavior before promoting it. `playbooks/eval.md`.
 - **Autonomous run.** A long task to drive to completion without stopping ("run until done", "/loop until X"). `playbooks/autonomous-run.md`.
 - **Session pickup.** Resuming or taking over a prior agent's in-flight work from a transcript, cloud-agent URL, or pushed branch. `playbooks/session-pickup.md`.
-- **Pause safely.** Suspending in-flight work cleanly so it can be resumed, on an explicit pause, going offline, a Cursor restart, or imminent context compaction. The complement to Session pickup. Full steps: `playbooks/pause-safely.md`.
+- **Pause safely.** Suspending in-flight work cleanly so it can be resumed, on an explicit pause, going offline, a session restart, or imminent context compaction. The complement to Session pickup. Full steps: `playbooks/pause-safely.md`.
 - **Multi-phase or multi-PR plan.** Work that spans phases or stacked PRs. `playbooks/multi-phase-plan.md`.
 - **Opening a PR.** Invoked at the end of every other playbook. `playbooks/opening-a-pr.md`.

--- a/plugins/pstack/skills/poteto-mode/playbooks/authoring-a-skill.md
+++ b/plugins/pstack/skills/poteto-mode/playbooks/authoring-a-skill.md
@@ -2,7 +2,7 @@
 
 **You own the skill's voice.** Agent-facing prose has a higher bar than human prose; unhelpful sentences become instructions.
 
-1. Use the **plugin-dev:skill-development** skill (Cursor's built-in for authoring SKILL.md files).
+1. Use the **plugin-dev:skill-development** skill (Claude Code's skill for authoring SKILL.md files).
 2. Validate the skill: frontmatter has `name` and `description`, referenced files exist, cross-skill links resolve.
 3. Test cases if structural; skip if subjective.
 4. Run **Opening a PR**.

--- a/plugins/pstack/skills/poteto-mode/playbooks/pause-safely.md
+++ b/plugins/pstack/skills/poteto-mode/playbooks/pause-safely.md
@@ -1,6 +1,6 @@
 ### Pause safely
 
-**You own a clean stop. Leave a checkpoint a cold-start agent can resume from.** For "pause safely", "I need to go offline", "restart Cursor", or "board my flight", and when context is about to compact or summarize. This is explicit only. On "keep going", "going to bed, keep going", or "don't stop", do not pause. Those mean continue, and Autonomous run already checkpoints per iteration.
+**You own a clean stop. Leave a checkpoint a cold-start agent can resume from.** For "pause safely", "I need to go offline", "restart Claude Code", or "board my flight", and when context is about to compact or summarize. This is explicit only. On "keep going", "going to bed, keep going", or "don't stop", do not pause. Those mean continue, and Autonomous run already checkpoints per iteration.
 
 1. Stop at a safe boundary. Finish the current atomic step or back out of it. Never stop mid-edit in a known-broken state. Start nothing new, and cancel any nested subagents.
 2. Don't cross an irreversible line to pause. No PR and no push unless you already had one out.

--- a/plugins/pstack/skills/poteto-mode/references/plan.md
+++ b/plugins/pstack/skills/poteto-mode/references/plan.md
@@ -73,7 +73,7 @@ Order phases so infrastructure and shared types land first (the **foundational-t
 
 For changes touching existing code, apply the **redesign-from-first-principles** principle skill: if we'd built this with the new requirement on day one, what would it look like? Redesign holistically; deliver incrementally.
 
-If a phase creates or edits a skill, the phase instructs the implementer to use the **plugin-dev:skill-development** skill (Cursor's built-in for authoring SKILL.md files).
+If a phase creates or edits a skill, the phase instructs the implementer to use the **plugin-dev:skill-development** skill (Claude Code's skill for authoring SKILL.md files).
 
 ## 5. Verification per phase
 


### PR DESCRIPTION
## Summary

Follow-up to PR #1 (the 0.9.2 upstream sync). The substitution pass re-applied the Cursor → Claude Code table across ~70 files but left a handful of Cursor-specific terms in **agent-facing skill prose** — the kind of stray that misleads an agent reading the skill, which is exactly what a clean port shouldn't ship.

Found by reviewing PR #1's diff (the exact-match grep audit in #1's test plan didn't catch these because it only matched `.cursor/` paths and specific primitives, not the word "Cursor" in prose).

## Fixes

- **`plugin-dev:skill-development` mis-described as "Cursor's built-in"** (self-contradictory — it's a Claude Code plugin skill). Three sites: `poteto-mode/references/plan.md`, `poteto-mode/playbooks/authoring-a-skill.md`, `automate-me/SKILL.md`.
- **"Cursor restart" / "restart Cursor"** → session / Claude Code restart. `poteto-mode/SKILL.md`, `poteto-mode/playbooks/pause-safely.md`.
- **"Bugbot"** (Cursor's proprietary PR-review bot, never fires in a Claude Code workflow) → "an automated PR-review bot". `poteto-mode/SKILL.md`.
- **`CHANGES.md` arena runner count `4` → `3`** to match the actual unified three-model panel (`arena/SKILL.md:28` and `CHANGES.md:29`).

## Left intentionally untouched

- `babysit`'s "Claude Code analog of Cursor's `/babysit`" framing — accurate provenance.
- `setup-pstack`'s `.mdc` contrast — intentional explanation of what Claude Code lacks.
- The illustrative `Bugbot flagged ...` log-line example in `reflect/references/synthesizer.md` — a quoted sample, not an instruction.

## Verification

`grep -rn "Cursor restart\|restart Cursor\|Cursor's built-in\|Bugbot" plugins/pstack/skills/` (excluding `babysit/` and `cursor-team-kit`) returns only the intentional `reflect` example line. recall/setup-pstack path rewrites and model ids were independently verified correct and are not touched here.