### PR TITLE
Add a Codex plugin build alongside Claude Code

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "pstack-claude",
+  "interface": {
+    "displayName": "pstack"
+  },
+  "plugins": [
+    {
+      "name": "pstack",
+      "source": {
+        "source": "local",
+        "path": "./plugins/pstack"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL",
+        "products": ["CODEX"]
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,30 @@
 # CHANGES — applied substitutions
 
-This port applies the Cursor → Claude Code substitutions in skill bodies. Earlier drafts left them flagged; this revision resolves them.
+This port applies the Cursor → Claude Code substitutions in skill bodies. Earlier drafts left them flagged; this revision resolves them. A later pass added a Codex build that shares the same skills; see [Codex port](#codex-port) below.
+
+## Codex port
+
+pstack also ships as a Codex plugin. The skill bodies are not forked or regenerated. The same `skills/` tree serves both runtimes. Skill prose stays in Claude Code tool language, and one mapping file does the Claude to Codex translation, following the pattern the official `superpowers` plugin uses.
+
+**Added.**
+
+- `plugins/pstack/.codex-plugin/plugin.json` is the Codex plugin manifest (`skills: ./skills/`), with key-parity to the `superpowers` Codex manifest.
+- `.agents/plugins/marketplace.json` is the Codex marketplace manifest at the repo root, sourcing `./plugins/pstack` the way the Claude `.claude-plugin/marketplace.json` does.
+- `plugins/pstack/skills/poteto-mode/references/codex-tools.md` is the single Claude to Codex map. It covers tool actions (`Agent` becomes `spawn_agent` / `wait_agent` / `close_agent`, `AskUserQuestion` becomes plain text, the todolist becomes `update_plan`), the `multi_agent` config flag, subagent policy (Codex has no `poteto-agent` type, so dispatch a `spawn_agent` told to read `poteto-mode` first), model slugs (`claude-*` becomes your configured Codex models), the Claude built-ins pstack names (`run`, `verify`, `loop`, `plugin-dev:skill-development`), and the instructions file (`AGENTS.md`).
+
+**Platform notes (pointer-only edits).**
+
+- `skills/poteto-mode/SKILL.md` gained a "Platform Adaptation" section pointing at the mapping.
+- `skills/{architect,arena,automate-me,babysit,how,interrogate,reflect,why}/SKILL.md` each gained a one-line Platform note, since each names a Claude tool, a `claude-*` slug, or a Claude built-in. The pure-prose skills (the `principle-*` set, `tdd`, `figure-it-out`, and the cursor-team-kit imports) needed nothing.
+- `skills/setup-pstack/SKILL.md` gained a Codex branch. It writes `~/.codex/pstack-models.md` referenced from `~/.codex/AGENTS.md`, using Codex slugs instead of `claude-*`.
+
+**Commands.** The 24 `commands/*.md` files are Codex-compatible as written, no rewrite needed. Codex command discovery reads the `description` frontmatter and the filename and ignores the extra `name` key, and each body (`Invoke the <skill> skill and follow it`) is a valid Codex prompt. They surface as slash commands once the full plugin is installed in Codex. For the symlink-based install, drop the same files into `~/.codex/prompts/` for loose `/name` shortcuts alongside the symlinked skills.
+
+**Deliberately not ported.**
+
+- `agents/poteto-agent.md`. Codex has no `subagent_type`, so ad-hoc subagents are dispatched via `spawn_agent` told to read `poteto-mode` first. The mapping covers this.
+
+**Verified.** Codex discovers the skills and namespaces them under `pstack` (`pstack:poteto-mode` and so on) in a live session. Mapping resolution mid-task and `spawn_agent` fan-out follow the `superpowers` pattern and are worth confirming per session.
 
 ## 0.9.2 sync (against upstream `e46364b`)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@ This port applies the Cursor → Claude Code substitutions in skill bodies. Earl
 
 ## Codex port
 
-pstack also ships as a Codex plugin. The skill bodies are not forked or regenerated. The same `skills/` tree serves both runtimes. Skill prose stays in Claude Code tool language, and one mapping file does the Claude to Codex translation, following the pattern the official `superpowers` plugin uses.
+pstack also ships as a Codex plugin. The skill bodies are not forked or regenerated. The same `skills/` tree serves both runtimes. One mapping file does the Claude-to-Codex translation. That single-mapping-file spine is the same one the official `superpowers` plugin ships for Codex.
+
+pstack diverges from superpowers in one respect, and it is deliberate. superpowers writes its skill prose in tool-neutral language ("dispatch a subagent"), so no skill names a runtime tool and no per-skill note is needed. pstack instead keeps the upstream Claude-native prose intact, to stay in lockstep with upstream sync, and adds a one-line Platform note to each skill that names a Claude primitive. The note points at the mapping. Rewriting 44 upstream skills into neutral language would fork them from upstream and was rejected for that reason.
 
 **Added.**
 
@@ -25,6 +27,8 @@ pstack also ships as a Codex plugin. The skill bodies are not forked or regenera
 - `agents/poteto-agent.md`. Codex has no `subagent_type`, so ad-hoc subagents are dispatched via `spawn_agent` told to read `poteto-mode` first. The mapping covers this.
 
 **Verified.** Codex discovers the skills and namespaces them under `pstack` (`pstack:poteto-mode` and so on) in a live session. Mapping resolution mid-task and `spawn_agent` fan-out follow the `superpowers` pattern and are worth confirming per session.
+
+**Maintenance.** The plugin version string now lives in three manifests: `plugins/pstack/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `plugins/pstack/.codex-plugin/plugin.json`. A version bump must update all three. `.agents/plugins/marketplace.json` carries no version field.
 
 ## 0.9.2 sync (against upstream `e46364b`)
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -26,6 +26,7 @@ Summary of structural changes:
 - `plugins/pstack/commands/<name>.md` stubs added so each public skill is reachable as a slash command in Claude Code.
 - Seven skills imported from `cursor-team-kit`: `deslop`, `thermo-nuclear-code-quality-review`, `make-pr-easy-to-review`, `fix-ci`, `fix-merge-conflicts`, `get-pr-comments`, `what-did-i-get-done`. All copied verbatim — no rewiring needed.
 - `plugins/pstack/skills/babysit/` is independently authored as the Claude Code analog of Cursor's `/babysit` built-in. It has no upstream pstack equivalent; its workflow is informed by Cursor's public `/babysit` behavior. No code or prose was copied from any source.
+- A Codex build shares the same `skills/` tree. It adds `plugins/pstack/.codex-plugin/plugin.json`, a root `.agents/plugins/marketplace.json`, and `plugins/pstack/skills/poteto-mode/references/codex-tools.md` (the Claude-to-Codex tool, model, and built-in map), plus a one-line Platform note in the skills that name a Claude primitive. The skill content itself is unchanged. See [CHANGES.md](CHANGES.md#codex-port).
 
 ## Modifications
 
@@ -35,6 +36,9 @@ Files authored for this port (not derived from upstream):
 
 - `plugins/pstack/.claude-plugin/plugin.json`
 - `.claude-plugin/marketplace.json` (repo root)
+- `plugins/pstack/.codex-plugin/plugin.json`
+- `.agents/plugins/marketplace.json` (repo root)
+- `plugins/pstack/skills/poteto-mode/references/codex-tools.md`
 - `plugins/pstack/commands/*.md`
 - `plugins/pstack/skills/babysit/SKILL.md` (independently authored; workflow informed by Cursor's public `/babysit` behavior)
 - `NOTICE.md` (this file)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# pstack for Claude Code
+# pstack for Claude Code and Codex
 
-Claude Code port of [poteto](https://x.com/poteto)'s [pstack](https://github.com/cursor/plugins/tree/main/pstack) plugin (synced against upstream `e46364b`, pstack v0.9.2). Original by Lauren Tan; ships MIT. Imports seven skills from [cursor-team-kit](https://github.com/cursor/plugins/tree/main/cursor-team-kit) (also MIT): `deslop`, `thermo-nuclear-code-quality-review`, `make-pr-easy-to-review`, `fix-ci`, `fix-merge-conflicts`, `get-pr-comments`, `what-did-i-get-done`.
+Claude Code port of [poteto](https://x.com/poteto)'s [pstack](https://github.com/cursor/plugins/tree/main/pstack) plugin (synced against upstream `e46364b`, pstack v0.9.2). The same `skills/` tree also ships as a Codex plugin; see [Running on Codex](#running-on-codex). Original by Lauren Tan; ships MIT. Imports seven skills from [cursor-team-kit](https://github.com/cursor/plugins/tree/main/cursor-team-kit) (also MIT): `deslop`, `thermo-nuclear-code-quality-review`, `make-pr-easy-to-review`, `fix-ci`, `fix-merge-conflicts`, `get-pr-comments`, `what-did-i-get-done`.
 
 > if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.
 
 This is not a verbatim copy. Skill bodies have been edited so every Cursor-specific primitive resolves to its Claude Code equivalent — see [Differences from upstream](#differences-from-upstream) for the full list. The exhaustive per-skill audit lives in [CHANGES.md](CHANGES.md); license attribution lives in [NOTICE.md](NOTICE.md); the upstream README is preserved verbatim at [README-UPSTREAM.md](README-UPSTREAM.md).
 
 ## Install
+
+### Claude Code
 
 This repo ships as a Claude Code marketplace containing one plugin (`pstack`).
 
@@ -15,16 +17,36 @@ This repo ships as a Claude Code marketplace containing one plugin (`pstack`).
 /plugin install pstack@pstack-claude
 ```
 
+### Codex
+
+The same plugin carries a `.codex-plugin/plugin.json` manifest and a root `.agents/plugins/marketplace.json`. The verified install is to link the plugin's skills into your cross-runtime skills directory:
+
+```shell
+git clone https://github.com/michael-denyer/pstack-claude
+cd pstack-claude
+for s in plugins/pstack/skills/*/; do ln -s "$PWD/$s" ~/.agents/skills/"$(basename "$s")"; done
+```
+
+Codex reads `plugins/pstack/.codex-plugin/plugin.json` through the links and namespaces the skills under the plugin, so they list as `pstack:poteto-mode`, `pstack:tdd`, and so on. To enable the multi-model and parallel-subagent skills (`interrogate`, `arena`, `how`, `why`, `reflect`, `architect`), turn on subagents in `~/.codex/config.toml`:
+
+```toml
+[features]
+multi_agent = true
+```
+
 ## Layout
 
 ```text
 .
-├── .claude-plugin/marketplace.json   # marketplace manifest (repo root)
+├── .claude-plugin/marketplace.json   # Claude Code marketplace manifest (repo root)
+├── .agents/plugins/marketplace.json  # Codex marketplace manifest (repo root)
 ├── plugins/pstack/                   # the plugin itself
-│   ├── .claude-plugin/plugin.json
-│   ├── skills/                       # 44 skills
-│   ├── commands/                     # 24 slash command stubs
-│   └── agents/poteto-agent.md
+│   ├── .claude-plugin/plugin.json    # Claude Code manifest
+│   ├── .codex-plugin/plugin.json     # Codex manifest (skills: ./skills/)
+│   ├── skills/                       # 44 skills (shared by both runtimes)
+│   │   └── poteto-mode/references/codex-tools.md  # Claude→Codex tool/model/skill map
+│   ├── commands/                     # 24 Claude slash command stubs (not ported to Codex)
+│   └── agents/poteto-agent.md        # Claude subagent (Codex routes via codex-tools.md)
 ├── LICENSE                           # pstack upstream MIT
 ├── LICENSE-cursor-team-kit           # cursor-team-kit upstream MIT
 ├── NOTICE.md                         # attribution table
@@ -33,6 +55,17 @@ This repo ships as a Claude Code marketplace containing one plugin (`pstack`).
 ```
 
 Plugin-internal path references in the docs below (`skills/<name>/`, `commands/<name>.md`) are relative to `plugins/pstack/`.
+
+## Running on Codex
+
+The Codex build shares one `skills/` tree with the Claude Code build. Nothing is forked or generated. The skill bodies stay in Claude Code tool language, and one mapping file does the translation, following the same pattern the official `superpowers` plugin uses for Codex.
+
+- **Skill invocation.** Codex loads `SKILL.md` natively. There is no `Skill` tool. You invoke a skill by name (ask for it, or pick `pstack:poteto-mode` from the list). The 24 Claude `/command` stubs are not ported; Codex discovers skills by description, so the stubs add nothing there. Codex supports plugin-level `commands/` if you later want explicit `/shortcuts`.
+- **Tool, model, and built-in mapping.** When a skill names a Claude tool (the `Agent` tool, `AskUserQuestion`), a `claude-*` model slug, or a Claude built-in skill (`run`, `verify`, `loop`, `plugin-dev:skill-development`), it resolves through [`skills/poteto-mode/references/codex-tools.md`](plugins/pstack/skills/poteto-mode/references/codex-tools.md). `poteto-mode` and every skill that names one of those carries a one-line **Platform note** pointing there.
+- **Subagents.** The `Agent` tool maps to Codex `spawn_agent` / `wait_agent` / `close_agent`, enabled by `multi_agent = true`. Parallel fan-out is multiple `spawn_agent` calls in one turn. Without the flag, `interrogate`, `arena`, `how`, `why`, `reflect`, and `architect` degrade to a single sequential pass. There is no `poteto-agent` subagent type on Codex; route ad-hoc subagents by dispatching a `spawn_agent` told to read `poteto-mode` first.
+- **Models.** The `claude-*` slugs in skills are Claude defaults. On Codex substitute your configured Codex models, keeping multi-model panels genuinely diverse. `/setup-pstack` writes `~/.codex/pstack-models.md` (referenced from `~/.codex/AGENTS.md`) with Codex slugs instead of `~/.claude/pstack-models.md`.
+
+Verified on a live Codex session: the plugin's skills are discovered and namespaced under `pstack`. The deeper behaviors (mapping resolution mid-task, `spawn_agent` fan-out) follow the proven `superpowers` pattern but are worth confirming in your own session.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd pstack-claude
 for s in plugins/pstack/skills/*/; do ln -s "$PWD/$s" ~/.agents/skills/"$(basename "$s")"; done
 ```
 
-Codex discovers the linked skills. The plugin namespace (`pstack:poteto-mode`, `pstack:tdd`, and so on) comes from `plugins/pstack/.codex-plugin/plugin.json`. The marketplace install carries that manifest cleanly. The flat symlink links each skill one directory below the manifest, so confirm the namespace still resolves on the symlink path in your own session before relying on it. To enable the multi-model and parallel-subagent skills (`interrogate`, `arena`, `how`, `why`, `reflect`, `architect`), turn on subagents in `~/.codex/config.toml`:
+Codex discovers the linked skills and namespaces them under the plugin, so they list as `pstack:poteto-mode`, `pstack:tdd`, and so on. The namespace comes from `plugins/pstack/.codex-plugin/plugin.json` and resolves through the flat symlinks, even though each linked skill sits one directory below that manifest (verified on a live session via this symlink install). To enable the multi-model and parallel-subagent skills (`interrogate`, `arena`, `how`, `why`, `reflect`, `architect`), turn on subagents in `~/.codex/config.toml`:
 
 ```toml
 [features]
@@ -75,7 +75,7 @@ The Codex build shares one `skills/` tree with the Claude Code build. Nothing is
 - **Subagents.** The `Agent` tool maps to Codex `spawn_agent` / `wait_agent` / `close_agent`, enabled by `multi_agent = true`. Parallel fan-out is multiple `spawn_agent` calls in one turn. Without the flag, `interrogate`, `arena`, `how`, `why`, `reflect`, and `architect` degrade to a single sequential pass. There is no `poteto-agent` subagent type on Codex; route ad-hoc subagents by dispatching a `spawn_agent` told to read `poteto-mode` first.
 - **Models.** The `claude-*` slugs in skills are Claude defaults. On Codex substitute your configured Codex models, keeping multi-model panels genuinely diverse. `/setup-pstack` writes `~/.codex/pstack-models.md` (referenced from `~/.codex/AGENTS.md`) with Codex slugs instead of `~/.claude/pstack-models.md`.
 
-Verified on a live Codex session: the plugin's skills are discovered. Namespacing under `pstack` and the deeper behaviors (mapping resolution mid-task, `spawn_agent` fan-out) follow the proven `superpowers` pattern but are worth confirming in your own session, especially on the symlink install path.
+Verified on a live Codex session installed via the symlinks: the user-facing skills are discovered and namespaced under `pstack` (`pstack:poteto-mode`, `pstack:interrogate`, and so on). The `principle-*` leaf skills carry `disable-model-invocation: true` and no command, so Codex does not surface them in the picker, the same as Claude Code. They stay installed for `poteto-mode` to read by path. The deeper behaviors (mapping resolution mid-task, `spawn_agent` fan-out) follow the proven `superpowers` pattern and are worth confirming in your own session.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd pstack-claude
 for s in plugins/pstack/skills/*/; do ln -s "$PWD/$s" ~/.agents/skills/"$(basename "$s")"; done
 ```
 
-Codex reads `plugins/pstack/.codex-plugin/plugin.json` through the links and namespaces the skills under the plugin, so they list as `pstack:poteto-mode`, `pstack:tdd`, and so on. To enable the multi-model and parallel-subagent skills (`interrogate`, `arena`, `how`, `why`, `reflect`, `architect`), turn on subagents in `~/.codex/config.toml`:
+Codex discovers the linked skills. The plugin namespace (`pstack:poteto-mode`, `pstack:tdd`, and so on) comes from `plugins/pstack/.codex-plugin/plugin.json`. The marketplace install carries that manifest cleanly. The flat symlink links each skill one directory below the manifest, so confirm the namespace still resolves on the symlink path in your own session before relying on it. To enable the multi-model and parallel-subagent skills (`interrogate`, `arena`, `how`, `why`, `reflect`, `architect`), turn on subagents in `~/.codex/config.toml`:
 
 ```toml
 [features]
@@ -67,7 +67,7 @@ Plugin-internal path references in the docs below (`skills/<name>/`, `commands/<
 
 ## Running on Codex
 
-The Codex build shares one `skills/` tree with the Claude Code build. Nothing is forked or generated. The skill bodies stay in Claude Code tool language, and one mapping file does the translation, following the same pattern the official `superpowers` plugin uses for Codex.
+The Codex build shares one `skills/` tree with the Claude Code build. Nothing is forked or generated. One mapping file does the translation. That single-mapping-file spine is the one `superpowers` ships for Codex. pstack diverges in one respect. superpowers writes its skills in tool-neutral language, so no skill names a runtime tool. pstack keeps the upstream Claude-native prose and adds a one-line Platform note to each skill that names a Claude primitive, so the port stays in lockstep with upstream sync.
 
 - **Skill invocation.** Codex loads `SKILL.md` natively. There is no `Skill` tool. You invoke a skill by name (ask for it, or pick `pstack:poteto-mode` from the list).
 - **Commands.** The 24 `commands/*.md` files are Codex-compatible as written. Codex reads their `description` frontmatter and the filename and ignores the extra `name` key, and each body invokes its skill. They surface as slash commands when the full plugin is installed, or you can link them into `~/.codex/prompts/` for `/name` shortcuts (see [Install on Codex](#codex)).
@@ -75,7 +75,7 @@ The Codex build shares one `skills/` tree with the Claude Code build. Nothing is
 - **Subagents.** The `Agent` tool maps to Codex `spawn_agent` / `wait_agent` / `close_agent`, enabled by `multi_agent = true`. Parallel fan-out is multiple `spawn_agent` calls in one turn. Without the flag, `interrogate`, `arena`, `how`, `why`, `reflect`, and `architect` degrade to a single sequential pass. There is no `poteto-agent` subagent type on Codex; route ad-hoc subagents by dispatching a `spawn_agent` told to read `poteto-mode` first.
 - **Models.** The `claude-*` slugs in skills are Claude defaults. On Codex substitute your configured Codex models, keeping multi-model panels genuinely diverse. `/setup-pstack` writes `~/.codex/pstack-models.md` (referenced from `~/.codex/AGENTS.md`) with Codex slugs instead of `~/.claude/pstack-models.md`.
 
-Verified on a live Codex session: the plugin's skills are discovered and namespaced under `pstack`. The deeper behaviors (mapping resolution mid-task, `spawn_agent` fan-out) follow the proven `superpowers` pattern but are worth confirming in your own session.
+Verified on a live Codex session: the plugin's skills are discovered. Namespacing under `pstack` and the deeper behaviors (mapping resolution mid-task, `spawn_agent` fan-out) follow the proven `superpowers` pattern but are worth confirming in your own session, especially on the symlink install path.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Codex reads `plugins/pstack/.codex-plugin/plugin.json` through the links and nam
 multi_agent = true
 ```
 
+For slash-command shortcuts (`/poteto-mode`, `/tdd`, and the rest), link the command files into Codex's prompts directory:
+
+```shell
+mkdir -p ~/.codex/prompts
+for c in plugins/pstack/commands/*.md; do ln -s "$PWD/$c" ~/.codex/prompts/"$(basename "$c")"; done
+```
+
+Each command invokes its skill, so `/tdd` runs the `tdd` skill. Installing the full plugin through the Codex marketplace (the root `.agents/plugins/marketplace.json`) carries skills and commands together; the two symlink steps above are the verified local path. Teardown is `rm ~/.agents/skills/<name>` and `rm ~/.codex/prompts/<name>.md`.
+
 ## Layout
 
 ```text
@@ -45,7 +54,7 @@ multi_agent = true
 │   ├── .codex-plugin/plugin.json     # Codex manifest (skills: ./skills/)
 │   ├── skills/                       # 44 skills (shared by both runtimes)
 │   │   └── poteto-mode/references/codex-tools.md  # Claude→Codex tool/model/skill map
-│   ├── commands/                     # 24 Claude slash command stubs (not ported to Codex)
+│   ├── commands/                     # 24 slash command stubs (Codex-compatible; link into ~/.codex/prompts)
 │   └── agents/poteto-agent.md        # Claude subagent (Codex routes via codex-tools.md)
 ├── LICENSE                           # pstack upstream MIT
 ├── LICENSE-cursor-team-kit           # cursor-team-kit upstream MIT
@@ -60,7 +69,8 @@ Plugin-internal path references in the docs below (`skills/<name>/`, `commands/<
 
 The Codex build shares one `skills/` tree with the Claude Code build. Nothing is forked or generated. The skill bodies stay in Claude Code tool language, and one mapping file does the translation, following the same pattern the official `superpowers` plugin uses for Codex.
 
-- **Skill invocation.** Codex loads `SKILL.md` natively. There is no `Skill` tool. You invoke a skill by name (ask for it, or pick `pstack:poteto-mode` from the list). The 24 Claude `/command` stubs are not ported; Codex discovers skills by description, so the stubs add nothing there. Codex supports plugin-level `commands/` if you later want explicit `/shortcuts`.
+- **Skill invocation.** Codex loads `SKILL.md` natively. There is no `Skill` tool. You invoke a skill by name (ask for it, or pick `pstack:poteto-mode` from the list).
+- **Commands.** The 24 `commands/*.md` files are Codex-compatible as written. Codex reads their `description` frontmatter and the filename and ignores the extra `name` key, and each body invokes its skill. They surface as slash commands when the full plugin is installed, or you can link them into `~/.codex/prompts/` for `/name` shortcuts (see [Install on Codex](#codex)).
 - **Tool, model, and built-in mapping.** When a skill names a Claude tool (the `Agent` tool, `AskUserQuestion`), a `claude-*` model slug, or a Claude built-in skill (`run`, `verify`, `loop`, `plugin-dev:skill-development`), it resolves through [`skills/poteto-mode/references/codex-tools.md`](plugins/pstack/skills/poteto-mode/references/codex-tools.md). `poteto-mode` and every skill that names one of those carries a one-line **Platform note** pointing there.
 - **Subagents.** The `Agent` tool maps to Codex `spawn_agent` / `wait_agent` / `close_agent`, enabled by `multi_agent = true`. Parallel fan-out is multiple `spawn_agent` calls in one turn. Without the flag, `interrogate`, `arena`, `how`, `why`, `reflect`, and `architect` degrade to a single sequential pass. There is no `poteto-agent` subagent type on Codex; route ad-hoc subagents by dispatching a `spawn_agent` told to read `poteto-mode` first.
 - **Models.** The `claude-*` slugs in skills are Claude defaults. On Codex substitute your configured Codex models, keeping multi-model panels genuinely diverse. `/setup-pstack` writes `~/.codex/pstack-models.md` (referenced from `~/.codex/AGENTS.md`) with Codex slugs instead of `~/.claude/pstack-models.md`.

--- a/plugins/pstack/.codex-plugin/plugin.json
+++ b/plugins/pstack/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "pstack",
+  "version": "0.9.2",
+  "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Codex port of the Claude Code plugin; skills are shared, tool names resolve via skills/poteto-mode/references/codex-tools.md.",
+  "author": {
+    "name": "Lauren Tan"
+  },
+  "homepage": "https://github.com/michael-denyer/pstack-claude",
+  "repository": "https://github.com/michael-denyer/pstack-claude",
+  "license": "MIT",
+  "keywords": [
+    "pstack",
+    "poteto-mode",
+    "workflow",
+    "principles",
+    "agent-style",
+    "subagents",
+    "unslop"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "pstack",
+    "shortDescription": "Rigorous, parallelizable agent workflows: go deep first, write less, verify everything",
+    "longDescription": "pstack guides agent work through poteto-mode's principles, parallel design exploration (architect/arena), adversarial multi-model review (interrogate), root-cause debugging, prose deslopping, and verified delivery. Skills are shared with the Claude Code build; on Codex, tool names resolve via the codex-tools mapping.",
+    "developerName": "Lauren Tan (original), Michael Denyer (Codex port)",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Work on this in poteto-mode.",
+      "Interrogate this diff with multiple models."
+    ],
+    "websiteURL": "https://github.com/michael-denyer/pstack-claude",
+    "brandColor": "#7C3AED"
+  }
+}

--- a/plugins/pstack/skills/architect/SKILL.md
+++ b/plugins/pstack/skills/architect/SKILL.md
@@ -6,9 +6,9 @@ disable-model-invocation: true
 
 # Architect
 
-**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
-
 Design before implementing. Sketch types, function signatures, class shapes, and module boundaries with `not implemented` bodies and pseudocode. Synthesize across multiple model perspectives, then fill in code against the chosen sketch. If implementation proves the sketch wrong, throw it out and redesign.
+
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below are Claude defaults. Resolve them via [`codex-tools.md`](../poteto-mode/references/codex-tools.md).
 
 ## Start
 

--- a/plugins/pstack/skills/architect/SKILL.md
+++ b/plugins/pstack/skills/architect/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Architect
 
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+
 Design before implementing. Sketch types, function signatures, class shapes, and module boundaries with `not implemented` bodies and pseudocode. Synthesize across multiple model perspectives, then fill in code against the chosen sketch. If implementation proves the sketch wrong, throw it out and redesign.
 
 ## Start

--- a/plugins/pstack/skills/arena/SKILL.md
+++ b/plugins/pstack/skills/arena/SKILL.md
@@ -6,9 +6,9 @@ disable-model-invocation: true
 
 # Arena
 
-**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
-
 Fan out N parallel attempts at the same task. Read every candidate end to end. Pick the strongest as the base. Graft the best ideas from the others into it. Verify the synthesized result.
+
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below are Claude defaults. Resolve them via [`codex-tools.md`](../poteto-mode/references/codex-tools.md).
 
 ## Start
 

--- a/plugins/pstack/skills/arena/SKILL.md
+++ b/plugins/pstack/skills/arena/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: true
 
 # Arena
 
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+
 Fan out N parallel attempts at the same task. Read every candidate end to end. Pick the strongest as the base. Graft the best ideas from the others into it. Verify the synthesized result.
 
 ## Start

--- a/plugins/pstack/skills/automate-me/SKILL.md
+++ b/plugins/pstack/skills/automate-me/SKILL.md
@@ -8,9 +8,9 @@ disable-model-invocation: true
 
 A guided flow for turning the user's working conventions into a skill agents will follow. The output is one `-mode` skill tailored to them (e.g. `jay-mode`, `priya-mode`).
 
-**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below (including `plugin-dev:skill-development`) are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
-
 This skill orchestrates three others: an inline mining pass (see step 1), the `plugin-dev:skill-development` skill (authoring), and the **unslop** skill (prose discipline). It sequences them; it doesn't replace them.
+
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below (including `plugin-dev:skill-development`) are Claude defaults. Resolve them via [`codex-tools.md`](../poteto-mode/references/codex-tools.md).
 
 ## Flow
 

--- a/plugins/pstack/skills/automate-me/SKILL.md
+++ b/plugins/pstack/skills/automate-me/SKILL.md
@@ -8,6 +8,8 @@ disable-model-invocation: true
 
 A guided flow for turning the user's working conventions into a skill agents will follow. The output is one `-mode` skill tailored to them (e.g. `jay-mode`, `priya-mode`).
 
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below (including `plugin-dev:skill-development`) are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+
 This skill orchestrates three others: an inline mining pass (see step 1), the `plugin-dev:skill-development` skill (authoring), and the **unslop** skill (prose discipline). It sequences them; it doesn't replace them.
 
 ## Flow

--- a/plugins/pstack/skills/babysit/SKILL.md
+++ b/plugins/pstack/skills/babysit/SKILL.md
@@ -7,6 +7,8 @@ description: Watch an open PR — fix failing CI, handle the straightforward rev
 
 Claude Code analog of Cursor's built-in `/babysit`. The implementation is a loop over `gh` CLI plus the Claude Code `loop` skill for pacing.
 
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names and Claude built-in skills named below (`loop`, `AskUserQuestion`) are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+
 ## When to use
 
 - There's an open PR and the user explicitly wants it kept green.

--- a/plugins/pstack/skills/babysit/SKILL.md
+++ b/plugins/pstack/skills/babysit/SKILL.md
@@ -7,7 +7,7 @@ description: Watch an open PR — fix failing CI, handle the straightforward rev
 
 Claude Code analog of Cursor's built-in `/babysit`. The implementation is a loop over `gh` CLI plus the Claude Code `loop` skill for pacing.
 
-**Platform note.** On Codex or another non-Claude runtime, the Claude tool names and Claude built-in skills named below (`loop`, `AskUserQuestion`) are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names and Claude built-in skills named below (`loop`, `AskUserQuestion`) are Claude defaults. Resolve them via [`codex-tools.md`](../poteto-mode/references/codex-tools.md).
 
 ## When to use
 

--- a/plugins/pstack/skills/how/SKILL.md
+++ b/plugins/pstack/skills/how/SKILL.md
@@ -7,6 +7,8 @@ description: "Use for \"how does X work\", code walkthroughs before changing som
 
 Explore the codebase to answer "how does X work?" questions. Produce clear architectural explanations at the level of a senior engineer onboarding onto a subsystem. Enough to build a working mental model, not annotated source code.
 
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names and `claude-*` slugs named below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+
 Two modes:
 
 1. **Explain** (default). Explore the codebase and produce a clear explanation

--- a/plugins/pstack/skills/how/SKILL.md
+++ b/plugins/pstack/skills/how/SKILL.md
@@ -7,7 +7,7 @@ description: "Use for \"how does X work\", code walkthroughs before changing som
 
 Explore the codebase to answer "how does X work?" questions. Produce clear architectural explanations at the level of a senior engineer onboarding onto a subsystem. Enough to build a working mental model, not annotated source code.
 
-**Platform note.** On Codex or another non-Claude runtime, the Claude tool names and `claude-*` slugs named below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names and `claude-*` slugs named below are Claude defaults. Resolve them via [`codex-tools.md`](../poteto-mode/references/codex-tools.md).
 
 Two modes:
 

--- a/plugins/pstack/skills/interrogate/SKILL.md
+++ b/plugins/pstack/skills/interrogate/SKILL.md
@@ -10,6 +10,8 @@ Spawn one reviewer per configured model to adversarially review code changes. Ea
 
 The deliverable is a synthesized verdict. Do NOT auto-apply changes.
 
+On Codex or another non-Claude runtime, the `subagent_type`/`model`/`readonly` dispatch fields and the `claude-*` model slugs below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md` (dispatch maps to `spawn_agent`; substitute your configured Codex models, keeping the panel model-diverse).
+
 ## Step 1, Determine Scope
 
 Identify what to review from context:

--- a/plugins/pstack/skills/interrogate/SKILL.md
+++ b/plugins/pstack/skills/interrogate/SKILL.md
@@ -10,7 +10,7 @@ Spawn one reviewer per configured model to adversarially review code changes. Ea
 
 The deliverable is a synthesized verdict. Do NOT auto-apply changes.
 
-On Codex or another non-Claude runtime, the `subagent_type`/`model`/`readonly` dispatch fields and the `claude-*` model slugs below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md` (dispatch maps to `spawn_agent`; substitute your configured Codex models, keeping the panel model-diverse).
+**Platform note.** On Codex or another non-Claude runtime, the `subagent_type`/`model`/`readonly` dispatch fields and the `claude-*` model slugs below are Claude defaults. Resolve them via [`codex-tools.md`](../poteto-mode/references/codex-tools.md) (dispatch maps to `spawn_agent`; substitute your configured Codex models, keeping the panel model-diverse).
 
 ## Step 1, Determine Scope
 

--- a/plugins/pstack/skills/poteto-mode/SKILL.md
+++ b/plugins/pstack/skills/poteto-mode/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 ## Platform Adaptation
 
-These skills use Claude Code tool names (the `Skill` tool, the `Agent` tool, `AskUserQuestion`) and Claude model slugs (`claude-opus-4-8`). On Claude Code they work as written. On Codex and other runtimes, the skills are the same files; only the tool, model, and built-in-skill names resolve differently. When a skill names a Claude tool, a `claude-*` model, or a Claude built-in skill (`run`, `verify`, `plugin-dev:skill-development`), read `references/codex-tools.md` for the Codex equivalent.
+These skills use Claude Code tool names (the `Skill` tool, the `Agent` tool, `AskUserQuestion`) and Claude model slugs (`claude-opus-4-8`). On Claude Code they work as written. On Codex and other runtimes, the skills are the same files; only the tool, model, and built-in-skill names resolve differently. When a skill names a Claude tool, a `claude-*` model, or a Claude built-in skill (`run`, `verify`, `plugin-dev:skill-development`), read [`references/codex-tools.md`](references/codex-tools.md) for the Codex equivalent.
 
 ## Non-negotiables
 

--- a/plugins/pstack/skills/poteto-mode/SKILL.md
+++ b/plugins/pstack/skills/poteto-mode/SKILL.md
@@ -6,6 +6,10 @@ disable-model-invocation: true
 
 # Poteto mode
 
+## Platform Adaptation
+
+These skills use Claude Code tool names (the `Skill` tool, the `Agent` tool, `AskUserQuestion`) and Claude model slugs (`claude-opus-4-8`). On Claude Code they work as written. On Codex and other runtimes, the skills are the same files; only the tool, model, and built-in-skill names resolve differently. When a skill names a Claude tool, a `claude-*` model, or a Claude built-in skill (`run`, `verify`, `plugin-dev:skill-development`), read `references/codex-tools.md` for the Codex equivalent.
+
 ## Non-negotiables
 
 **Start every multi-step task with a todolist whose first item is to read the Principles section below in full.** The principles ground every trigger here. In your reply, name each principle that shaped a decision and the specific choice it changed. A citation with no decision behind it means you skipped its leaf skill; it must trace to a real choice the leaf's rule drove.

--- a/plugins/pstack/skills/poteto-mode/references/codex-tools.md
+++ b/plugins/pstack/skills/poteto-mode/references/codex-tools.md
@@ -1,0 +1,61 @@
+# Codex tool mapping for pstack
+
+pstack skills are written in Claude Code tool language (the `Skill` tool, the `Agent` tool, `AskUserQuestion`, model slugs like `claude-opus-4-8`). On Codex the skills are the same files; only the tool names resolve differently. Read this when a pstack skill names a Claude tool, a Claude built-in skill, or a `claude-*` model.
+
+## Tool actions
+
+| pstack / Claude action | Codex equivalent |
+|------------------------|------------------|
+| Read a file | `shell` (`cat`, `head`, `tail`) |
+| Create / edit / delete a file | `apply_patch` |
+| Run a shell command | `shell` |
+| Search file contents / find files | `shell` (`rg`, `grep`, `find`, `ls`) |
+| Fetch a URL | `shell` with `curl` / `wget` |
+| Search the web | `web_search` |
+| Invoke a skill (the `Skill` tool, `/command`) | Skills load natively. Follow the instructions presented. |
+| Dispatch a subagent (the `Agent`/`Task` tool) | `spawn_agent` |
+| Dispatch N parallel subagents in one turn | N `spawn_agent` calls in one response |
+| Wait for a subagent result | `wait_agent` |
+| Free a finished subagent slot | `close_agent` |
+| Track tasks (the todolist / `TodoWrite`) | `update_plan` |
+| Ask the human a fixed-choice question (`AskUserQuestion`) | Ask in plain text and let the user answer. Codex has no structured-choice tool. |
+
+Subagent dispatch needs `multi_agent` enabled. Add to `~/.codex/config.toml`:
+
+```toml
+[features]
+multi_agent = true
+```
+
+Without it, `spawn_agent` is unavailable and the fan-out skills (`interrogate`, `why`, `how`, `arena`, `reflect`) degrade to a single sequential pass.
+
+## Subagent policy
+
+poteto-mode's Subagents section sets Claude-specific defaults (`subagent_type: "poteto-agent"`, `run_in_background: true`). On Codex:
+
+- There is no `poteto-agent` subagent type. Route an ad-hoc subagent through poteto-mode's style by dispatching a `spawn_agent` whose instructions tell it to read the `poteto-mode` skill in full first.
+- `spawn_agent` calls already run concurrently with your turn, so `run_in_background: true` has no separate flag. Issue the dispatch and continue.
+- Keep the rest of the policy unchanged. Pass file pointers not inlined context, give each worker its own worktree or branch when they write, review every subagent's diff yourself.
+
+## Model names
+
+Skills name Claude defaults (`claude-opus-4-8` for code/prose/judgment; the `claude-opus-4-8` + `claude-opus-4-6` + `claude-sonnet-4-6` triple for diverse-model panels). These slugs do not resolve on Codex. Substitute your configured Codex models:
+
+- Single-model roles: your primary Codex model (for example `gpt-5.5`).
+- Diverse-model panels (`interrogate`, `how` critics, `reflect`): the adversarial signal comes from model diversity, so use the distinct Codex models available to you. If only one model family is reachable, vary reasoning effort and note in the verdict that diversity was reduced.
+
+`/setup-pstack` writes the configured model list. On Codex, set it to your Codex model slugs.
+
+## Claude built-in skills pstack references
+
+Some triggers name skills that ship with Claude Code, not pstack. They do not exist on Codex. Substitute the behavior:
+
+| Claude built-in named in pstack | On Codex |
+|---------------------------------|----------|
+| `run` (drive a CLI/TUI to see a change work) | Run the app yourself via `shell` and observe the real output. |
+| `verify` (drive a UI to confirm a fix) | Drive the UI with whatever automation you have, or hand the user a concrete manual check. Do not claim done without observing the artifact. |
+| `plugin-dev:skill-development` (Claude's SKILL.md authoring guidance) | Follow your platform's skill-authoring guidance; the `writing-skills` skill if present. Keep `name` + `description` frontmatter and progressive disclosure. |
+
+## Instructions file
+
+Where a pstack skill says "your instructions file", on Codex that is `AGENTS.md` (project root, plus `~/.codex/AGENTS.md` global). On Claude Code it is `CLAUDE.md`.

--- a/plugins/pstack/skills/poteto-mode/references/codex-tools.md
+++ b/plugins/pstack/skills/poteto-mode/references/codex-tools.md
@@ -55,6 +55,7 @@ Some triggers name skills that ship with Claude Code, not pstack. They do not ex
 | `run` (drive a CLI/TUI to see a change work) | Run the app yourself via `shell` and observe the real output. |
 | `verify` (drive a UI to confirm a fix) | Drive the UI with whatever automation you have, or hand the user a concrete manual check. Do not claim done without observing the artifact. |
 | `plugin-dev:skill-development` (Claude's SKILL.md authoring guidance) | Follow your platform's skill-authoring guidance; the `writing-skills` skill if present. Keep `name` + `description` frontmatter and progressive disclosure. |
+| `loop` (recurring/self-paced re-invocation, used by `babysit`) | Codex has no `loop` skill. Re-run the step yourself on a cadence, or use a Codex scheduled task if available. |
 
 ## Instructions file
 

--- a/plugins/pstack/skills/reflect/SKILL.md
+++ b/plugins/pstack/skills/reflect/SKILL.md
@@ -8,6 +8,8 @@ disable-model-invocation: true
 
 Mine the current conversation for durable learnings, then route them into skill edits.
 
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+
 ## When to invoke
 
 - The user said "reflect" or "/reflect".

--- a/plugins/pstack/skills/reflect/SKILL.md
+++ b/plugins/pstack/skills/reflect/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 Mine the current conversation for durable learnings, then route them into skill edits.
 
-**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names, `claude-*` slugs, and Claude built-in skills named below are Claude defaults. Resolve them via [`codex-tools.md`](../poteto-mode/references/codex-tools.md).
 
 ## When to invoke
 

--- a/plugins/pstack/skills/setup-pstack/SKILL.md
+++ b/plugins/pstack/skills/setup-pstack/SKILL.md
@@ -7,7 +7,7 @@ description: Configure which models pstack uses per role. Detects your available
 
 Write `~/.claude/pstack-models.md`, a per-role model override sheet you include from your global `CLAUDE.md`. Each pstack skill names a default model inline; the override sheet is the layer that adapts those defaults to the models you actually have access to.
 
-**Platform note (Codex/non-Claude runtimes).** On Codex the override sheet is `~/.codex/pstack-models.md`, the slugs are your Codex models (for example `gpt-5.5`) not `claude-*`, and you load it by adding the sheet's contents to `~/.codex/AGENTS.md` (Codex has no `@`-include into a rules file). The role rows in step 5 are identical; only the slugs, the file path, and the load mechanism change. Detect Codex slugs from `~/.codex/config.toml` (`model = ...`) plus whatever the user confirms. See `../poteto-mode/references/codex-tools.md`.
+**Platform note.** On Codex or another non-Claude runtime, the override sheet is `~/.codex/pstack-models.md`, the slugs are your Codex models (for example `gpt-5.5`) not `claude-*`, and you load it by adding the sheet's contents to `~/.codex/AGENTS.md` (Codex has no `@`-include into a rules file). The role rows in step 5 are identical; only the slugs, the file path, and the load mechanism change. Detect Codex slugs from `~/.codex/config.toml` (`model = ...`) plus whatever the user confirms. See [`codex-tools.md`](../poteto-mode/references/codex-tools.md).
 
 Claude Code has no auto-applied "rules" mechanism like Cursor's `.mdc`. Inclusion is explicit: the user adds a line to `~/.claude/CLAUDE.md` (or their project `CLAUDE.md`) such as:
 

--- a/plugins/pstack/skills/setup-pstack/SKILL.md
+++ b/plugins/pstack/skills/setup-pstack/SKILL.md
@@ -7,6 +7,8 @@ description: Configure which models pstack uses per role. Detects your available
 
 Write `~/.claude/pstack-models.md`, a per-role model override sheet you include from your global `CLAUDE.md`. Each pstack skill names a default model inline; the override sheet is the layer that adapts those defaults to the models you actually have access to.
 
+**Platform note (Codex/non-Claude runtimes).** On Codex the override sheet is `~/.codex/pstack-models.md`, the slugs are your Codex models (for example `gpt-5.5`) not `claude-*`, and you load it by adding the sheet's contents to `~/.codex/AGENTS.md` (Codex has no `@`-include into a rules file). The role rows in step 5 are identical; only the slugs, the file path, and the load mechanism change. Detect Codex slugs from `~/.codex/config.toml` (`model = ...`) plus whatever the user confirms. See `../poteto-mode/references/codex-tools.md`.
+
 Claude Code has no auto-applied "rules" mechanism like Cursor's `.mdc`. Inclusion is explicit: the user adds a line to `~/.claude/CLAUDE.md` (or their project `CLAUDE.md`) such as:
 
 ```text

--- a/plugins/pstack/skills/why/SKILL.md
+++ b/plugins/pstack/skills/why/SKILL.md
@@ -9,7 +9,7 @@ Investigate the motivation and intent behind code. Why was it built this way? Wh
 
 Companion to the `how` skill. `how` answers what the code does and how it works. `why` answers what forces led to its shape.
 
-**Platform note.** On Codex or another non-Claude runtime, the Claude tool names and `claude-*` slugs named below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names and `claude-*` slugs named below are Claude defaults. Resolve them via [`codex-tools.md`](../poteto-mode/references/codex-tools.md).
 
 ## How this skill works
 

--- a/plugins/pstack/skills/why/SKILL.md
+++ b/plugins/pstack/skills/why/SKILL.md
@@ -9,6 +9,8 @@ Investigate the motivation and intent behind code. Why was it built this way? Wh
 
 Companion to the `how` skill. `how` answers what the code does and how it works. `why` answers what forces led to its shape.
 
+**Platform note.** On Codex or another non-Claude runtime, the Claude tool names and `claude-*` slugs named below are Claude defaults. Resolve them via `../poteto-mode/references/codex-tools.md`.
+
 ## How this skill works
 
 Historical context spreads across seven evidence categories: source control history, issue or ticket tracking, long-form documents, real-time team chat, infrastructure observability, error or exception tracking, and product analytics warehouses. You cannot predict from the question alone which one holds the answer, so the skill enumerates available MCPs at run time, maps each to a category, queries all seven in parallel, then synthesizes with explicit confidence calibration. Null results from searched categories are first-class evidence about how the decision was made; report them alongside positive findings. The default is coverage, not minimalism.


### PR DESCRIPTION
## What

pstack now ships for **both Claude Code and Codex** from one shared `skills/` tree. No fork, no codegen.

## Approach

Mirrors how the official `superpowers` plugin targets Codex:

- **Shared skills.** Skill bodies stay in Claude Code tool language. One mapping file, [`skills/poteto-mode/references/codex-tools.md`](plugins/pstack/skills/poteto-mode/references/codex-tools.md), resolves Claude tools (`Agent`/`AskUserQuestion`), `claude-*` model slugs, and Claude built-in skills (`run`, `verify`, `loop`, `plugin-dev:skill-development`) to Codex equivalents (`spawn_agent`/`wait_agent`, your Codex models, `shell`).
- **Pointers, not rewrites.** `poteto-mode` carries a Platform Adaptation section; every standalone skill that names a Claude tool/slug/built-in (architect, arena, automate-me, babysit, how, interrogate, reflect, setup-pstack, why) carries a one-line Platform note. Pure-prose skills (the `principle-*` set, tdd, etc.) needed nothing.
- **Manifests.** `plugins/pstack/.codex-plugin/plugin.json` (`skills: ./skills/`) and a root `.agents/plugins/marketplace.json`, both with key-parity to the working superpowers Codex plugin.
- **setup-pstack** gained a Codex branch: write `~/.codex/pstack-models.md` referenced from `~/.codex/AGENTS.md`, with Codex slugs.

## Commands

The 24 `commands/*.md` files are **Codex-compatible as written** (zero edits). Codex command discovery reads the `description` frontmatter and the filename, ignores the extra `name` key, and each body invokes its skill. They surface as slash commands when the full plugin is installed, or link them into `~/.codex/prompts/` for `/name` shortcuts alongside the symlinked skills.

## Deliberately not ported

`agents/poteto-agent.md`. Codex has no `subagent_type`; ad-hoc subagents are dispatched via `spawn_agent` told to read `poteto-mode` first (covered by the mapping).

## Install on Codex

Two verified local steps (see README "Install on Codex"): symlink `plugins/pstack/skills/*` into `~/.agents/skills/`, and symlink `plugins/pstack/commands/*` into `~/.codex/prompts/`. The full plugin via the Codex marketplace carries both together.

## Verification

- Structural: all manifests valid JSON, Codex marketplace path resolves to the plugin, all 10 token-bearing skills covered (0 missing), mapping covers all 5 named built-ins, Claude manifests untouched, doc anchors resolve.
- **Live Codex (real artifact):** the plugin's skills are discovered and namespaced under `pstack` (`pstack:poteto-mode`, `pstack:tdd`, `pstack:interrogate` confirmed in a Codex session).
- Not yet exercised in-session: mapping resolution mid-task and `spawn_agent` fan-out. They follow the proven superpowers pattern; worth a confirming run.

## Follow-ups

- Confirm the fan-out skills under `multi_agent = true` on Codex.
- Optionally extend `CHANGES.md` with a deeper per-skill Codex audit (today the README "Running on Codex" + CHANGES "Codex port" sections cover it).