### PR TITLE
fix: drop the plugin-dev dependency declaration so the desktop app loads pstack

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,12 @@
     "name": "Michael Denyer"
   },
   "description": "Claude Code port of poteto's pstack. Rigorous agent workflows with Cursor primitives translated to Claude Code equivalents.",
-  "allowCrossMarketplaceDependenciesOn": ["claude-plugins-official"],
   "plugins": [
     {
       "name": "pstack",
       "source": "./plugins/pstack",
       "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "author": {
         "name": "Lauren Tan (original)"
       },

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This port applies the Cursor → Claude Code substitutions in skill bodies. Earlier drafts left them flagged; this revision resolves them. A later pass added a Codex build that shares the same skills; see [Codex port](#codex-port) below.
 
+## 0.9.3 — dependency declaration removed
+
+`plugin.json` no longer declares `dependencies: [{ "name": "plugin-dev", "marketplace": "claude-plugins-official" }]`, and `marketplace.json` drops the matching `allowCrossMarketplaceDependenciesOn`. The Claude Code desktop app passes every enabled plugin to the CLI as a session-only `--plugin-dir`, which strips marketplace identity (`pstack@inline`); a cross-marketplace dependency can never resolve in that mode, and the loader disables the entire plugin with `dependency-unsatisfied`. Result: pstack loaded in the CLI and the VS Code extension but silently vanished from desktop-app sessions. `optional: true` on a dependency entry passes `claude plugin validate` but is not honored by the loader (tested on 2.1.197). `plugin-dev` is now a documented manual install (README → Dependencies); skill bodies still route skill-authoring to `plugin-dev:skill-development` when it is present.
+
 ## Codex port
 
 pstack also ships as a Codex plugin. The skill bodies are not forked or regenerated. The same `skills/` tree serves both runtimes. One mapping file does the Claude-to-Codex translation. That single-mapping-file spine is the same one the official `superpowers` plugin ships for Codex.

--- a/README.md
+++ b/README.md
@@ -79,13 +79,16 @@ Verified on a live Codex session installed via the symlinks: the user-facing ski
 
 ## Dependencies
 
-Declared in `plugin.json` and auto-resolved on install:
+Nothing is declared in `plugin.json`. Install the one companion plugin yourself:
 
-- **`plugin-dev`** (from the `claude-plugins-official` marketplace) — required. The rewiring routes skill-authoring tasks (in `automate-me`, `reflect`, `poteto-mode`) to the `plugin-dev:skill-development` skill. If you haven't added the official marketplace yet, `/plugin install pstack@pstack-claude` will pull it in automatically, provided `claude-plugins-official` is already added; otherwise:
+- **`plugin-dev`** (from the `claude-plugins-official` marketplace) — the rewiring routes skill-authoring tasks (in `automate-me`, `reflect`, `poteto-mode`) to the `plugin-dev:skill-development` skill:
 
   ```shell
   /plugin marketplace add anthropics/claude-plugins-official
+  /plugin install plugin-dev@claude-plugins-official
   ```
+
+  Until 0.9.2 this was a `dependencies` entry in `plugin.json`, auto-resolved on marketplace install. The Claude Code desktop app, however, passes every plugin to the CLI as a session-only `--plugin-dir`, which strips marketplace identity (the plugin becomes `pstack@inline`). A cross-marketplace dependency can never resolve in that mode, so the loader disabled the whole plugin with `dependency-unsatisfied` — pstack silently vanished from every desktop-app session while working in the CLI and VS Code. `optional: true` on a dependency entry validates but is not honored (tested on 2.1.197), so 0.9.3 demotes the dependency to documentation. Without `plugin-dev` installed, only the skill-authoring routes degrade; everything else works.
 
 Not declared as deps, but referenced in skill bodies:
 

--- a/plugins/pstack/.claude-plugin/plugin.json
+++ b/plugins/pstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pstack",
   "displayName": "pstack (Claude Code port)",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Ported from cursor/plugins/pstack to Claude Code.",
   "author": {
     "name": "Lauren Tan"
@@ -17,8 +17,5 @@
     "agent-style",
     "subagents",
     "unslop"
-  ],
-  "dependencies": [
-    { "name": "plugin-dev", "marketplace": "claude-plugins-official" }
   ]
 }

--- a/plugins/pstack/.codex-plugin/plugin.json
+++ b/plugins/pstack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pstack",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Codex port of the Claude Code plugin; skills are shared, tool names resolve via skills/poteto-mode/references/codex-tools.md.",
   "author": {
     "name": "Lauren Tan"


### PR DESCRIPTION
The Claude Code desktop app passes every enabled plugin to the CLI as a session-only `--plugin-dir`, which strips marketplace identity (`pstack@inline`). The cross-marketplace dependency on `plugin-dev@claude-plugins-official` can never resolve in that mode, and the loader disables the entire plugin with `dependency-unsatisfied` — pstack loaded in the CLI and VS Code but silently vanished from desktop-app sessions.

`optional: true` on a dependency entry passes `claude plugin validate` but is not honored by the loader (tested on 2.1.197), so the dependency is demoted to documentation: README > Dependencies now carries the manual `plugin-dev` install steps. `marketplace.json` drops the matching `allowCrossMarketplaceDependenciesOn`.

Verified by spawning the desktop bundle's binary with `--plugin-dir plugins/pstack`: before, `Found 1 plugins (0 enabled, 1 disabled)` with `dependency-unsatisfied`; after, `1 enabled`, 44 skills and the poteto-agent load.

Bump 0.9.2 -> 0.9.3.