### PR TITLE
feat: add claude-sonnet-5 to the default multi-model panels

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pstack",
       "source": "./plugins/pstack",
       "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "author": {
         "name": "Lauren Tan (original)"
       },

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This port applies the Cursor → Claude Code substitutions in skill bodies. Earlier drafts left them flagged; this revision resolves them. A later pass added a Codex build that shares the same skills; see [Codex port](#codex-port) below.
 
+## 0.9.4 — Sonnet 5 joins the default panels
+
+The multi-model panels (`arena` runners, `architect` runners, `interrogate` reviewers, `how` critics) grow from a triple to a quad: `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-sonnet-4-6` — both generations in each of two tiers. This also restores upstream's four-way `interrogate` split; the port had been running three reviewers under a "four different models" description. `setup-pstack` adds Sonnet 5 (`claude-sonnet-5`) to the available-family enumeration and to the four panel rows of its default sheet. Single-model delegation defaults stay `claude-opus-4-8`. Touched: `arena`, `architect`, `interrogate`, `how`, `setup-pstack`, `poteto-mode` (`SKILL.md`, `references/plan.md`, `references/codex-tools.md`), and the README substitution-table panel row. The historical Cursor→Claude mapping rows (`composer-2.5-fast`, `gpt-5.x`) are unchanged — they record what the 0.9.2 sync substituted, not current defaults.
+
 ## 0.9.3 — dependency declaration removed
 
 `plugin.json` no longer declares `dependencies: [{ "name": "plugin-dev", "marketplace": "claude-plugins-official" }]`, and `marketplace.json` drops the matching `allowCrossMarketplaceDependenciesOn`. The Claude Code desktop app passes every enabled plugin to the CLI as a session-only `--plugin-dir`, which strips marketplace identity (`pstack@inline`); a cross-marketplace dependency can never resolve in that mode, and the loader disables the entire plugin with `dependency-unsatisfied`. Result: pstack loaded in the CLI and the VS Code extension but silently vanished from desktop-app sessions. `optional: true` on a dependency entry passes `claude plugin validate` but is not honored by the loader (tested on 2.1.197). `plugin-dev` is now a documented manual install (README → Dependencies); skill bodies still route skill-authoring to `plugin-dev:skill-development` when it is present.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The port is editorial, not mechanical. Anywhere upstream pstack assumed Cursor-s
 | Model `composer-2.5-fast` (Cursor) | `claude-sonnet-4-6` |
 | Model `claude-opus-4-X-thinking-xhigh` (Cursor UI variant) | `claude-opus-4-8` (extended thinking configured separately) |
 | Models `gpt-5.3-codex-high-fast`, `gpt-5.5-high-fast` (via Cursor) | `claude-sonnet-4-6`, `claude-haiku-4-5` (Claude family) |
-| Multi-model panels (arena, architect, interrogate, how-critics) | Default triple is `claude-opus-4-8` + `claude-opus-4-6` + `claude-sonnet-4-6` — three distinct models for cross-generation diversity inside the opus tier (replaces the cross-vendor diversity lost in translation). |
+| Multi-model panels (arena, architect, interrogate, how-critics) | Default quad is `claude-opus-4-8` + `claude-sonnet-5` + `claude-opus-4-6` + `claude-sonnet-4-6` — four distinct models across two generations and two tiers (replaces the cross-vendor diversity lost in translation and restores upstream's four-way split). |
 
 ### What's lost in translation
 

--- a/plugins/pstack/.claude-plugin/plugin.json
+++ b/plugins/pstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pstack",
   "displayName": "pstack (Claude Code port)",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Ported from cursor/plugins/pstack to Claude Code.",
   "author": {
     "name": "Lauren Tan"

--- a/plugins/pstack/.codex-plugin/plugin.json
+++ b/plugins/pstack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pstack",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Codex port of the Claude Code plugin; skills are shared, tool names resolve via skills/poteto-mode/references/codex-tools.md.",
   "author": {
     "name": "Lauren Tan"

--- a/plugins/pstack/skills/architect/SKILL.md
+++ b/plugins/pstack/skills/architect/SKILL.md
@@ -32,7 +32,7 @@ Skip Phase A only when the work is genuinely greenfield with no surrounding syst
 
 Run the **arena** skill with the design-sketch task and the Phase A grounding artifacts. Pass `references/runner-prompt.md` as each runner's prompt. Each candidate produces a design package shaped per `references/rationale-template.md`: the caller's usage written first, then the type sketch, function signatures, module map, and prose rationale derived from it.
 
-Use your configured architect runners (defaults `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-4-6`).
+Use your configured architect runners (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-sonnet-4-6`).
 
 This is the **exhaust-the-design-space** principle skill made concrete. Whole-shape alternatives, not point fixes inside one shape.
 

--- a/plugins/pstack/skills/arena/SKILL.md
+++ b/plugins/pstack/skills/arena/SKILL.md
@@ -27,7 +27,7 @@ The N candidates will receive the same prompt, so the prompt is the contract. Ge
 
 1. State the artifact each candidate is producing.
 2. Derive the rubric. State what success looks like for *this* task, then turn it into 3-6 concrete gradeable criteria. Concrete: `Adds a --dry-run flag that skips writes`. Vague: `code is correct`. The rubric is the picker's tool in Phase D; candidates only see the task.
-3. Pick the runners. Default runners are your configured arena list (defaults `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-4-6`). Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
+3. Pick the runners. Default runners are your configured arena list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-sonnet-4-6`). Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
 4. Assign output paths. Each candidate writes to its own location (a git worktree where possible, otherwise `/tmp/arena-<slug>/candidate-<n>/`). N candidates writing to the same path is shared mutable state and fails the the **separate-before-serializing-shared-state** principle skill test.
 
 ## Phase B: Fan out

--- a/plugins/pstack/skills/how/SKILL.md
+++ b/plugins/pstack/skills/how/SKILL.md
@@ -111,7 +111,7 @@ Run the full explain flow above (Steps 1-4). You must understand the architectur
 
 ### Step 2. Spawn Critics
 
-After the explanation is complete, spawn one architectural critic per model in your configured how-critics list (defaults `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-4-6`), all in a single message.
+After the explanation is complete, spawn one architectural critic per model in your configured how-critics list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-sonnet-4-6`), all in a single message.
 
 For each critic:
 - `subagent_type`: `general-purpose`

--- a/plugins/pstack/skills/interrogate/SKILL.md
+++ b/plugins/pstack/skills/interrogate/SKILL.md
@@ -35,7 +35,7 @@ Write one clear paragraph. Reviewers challenge whether the work achieves the int
 
 ## Step 3, Spawn Reviewers
 
-Launch one reviewer per model in your configured interrogate list (defaults `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-4-6`), all in a single message.
+Launch one reviewer per model in your configured interrogate list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-sonnet-4-6`), all in a single message.
 
 For each reviewer:
 - `subagent_type`: `general-purpose`

--- a/plugins/pstack/skills/poteto-mode/SKILL.md
+++ b/plugins/pstack/skills/poteto-mode/SKILL.md
@@ -83,7 +83,7 @@ Read the leaf skill in full for any principle you apply. Each entry names when i
 
 **Use `subagent_type: "poteto-agent"` for any subagent you spawn inside a playbook step** (code-writing delegates, ad-hoc helpers). `/poteto-mode` and `poteto-agent` route through the same wrapper. Routed workflow skills (`how`, `why`, `interrogate`, `reflect`) set their own `subagent_type` for diverse-model review; respect what the skill prescribes, don't override to `poteto-agent`.
 
-**Defaults for every `Agent` call.** `run_in_background: true`, full tool access (do not pick a subagent_type that strips MCP), file pointers not inlined context, explicit model per role (configurable via `/setup-pstack`; default `claude-opus-4-8` for code-writing delegations, prose, and judgment; multi-model panels run the `claude-opus-4-8` + `claude-opus-4-6` + `claude-sonnet-4-6` triple for diversity).
+**Defaults for every `Agent` call.** `run_in_background: true`, full tool access (do not pick a subagent_type that strips MCP), file pointers not inlined context, explicit model per role (configurable via `/setup-pstack`; default `claude-opus-4-8` for code-writing delegations, prose, and judgment; multi-model panels run the `claude-opus-4-8` + `claude-sonnet-5` + `claude-opus-4-6` + `claude-sonnet-4-6` quad for diversity).
 
 You own every subagent's work. Review the diff and write your own summary, don't pass through what it said. Interrupt-chained resumes silently drop directives, so fire a fresh subagent with consolidated scope rather than trusting a "done" summary. A second opinion is the same prompt against a different model. Agreement is high-signal.
 

--- a/plugins/pstack/skills/poteto-mode/references/codex-tools.md
+++ b/plugins/pstack/skills/poteto-mode/references/codex-tools.md
@@ -39,7 +39,7 @@ poteto-mode's Subagents section sets Claude-specific defaults (`subagent_type: "
 
 ## Model names
 
-Skills name Claude defaults (`claude-opus-4-8` for code/prose/judgment; the `claude-opus-4-8` + `claude-opus-4-6` + `claude-sonnet-4-6` triple for diverse-model panels). These slugs do not resolve on Codex. Substitute your configured Codex models:
+Skills name Claude defaults (`claude-opus-4-8` for code/prose/judgment; the `claude-opus-4-8` + `claude-sonnet-5` + `claude-opus-4-6` + `claude-sonnet-4-6` quad for diverse-model panels). These slugs do not resolve on Codex. Substitute your configured Codex models:
 
 - Single-model roles: your primary Codex model (for example `gpt-5.5`).
 - Diverse-model panels (`interrogate`, `how` critics, `reflect`): the adversarial signal comes from model diversity, so use the distinct Codex models available to you. If only one model family is reachable, vary reasoning effort and note in the verdict that diversity was reduced.

--- a/plugins/pstack/skills/poteto-mode/references/plan.md
+++ b/plugins/pstack/skills/poteto-mode/references/plan.md
@@ -25,7 +25,7 @@ Resolve what is in scope vs explicitly out, technical or platform constraints, p
 Delegate codebase exploration (the **guard-the-context-window** principle skill).
 
 - Prefer `subagent_type: "poteto-agent"`. `general-purpose` is the fallback. Never use Claude Code's built-in `Plan` agent; it ignores this skill.
-- Pass `model:` explicitly per the configured roles (default `claude-opus-4-8` for code-writing delegations and judgment; multi-model panels run the `claude-opus-4-8` + `claude-opus-4-6` + `claude-sonnet-4-6` triple).
+- Pass `model:` explicitly per the configured roles (default `claude-opus-4-8` for code-writing delegations and judgment; multi-model panels run the `claude-opus-4-8` + `claude-sonnet-5` + `claude-opus-4-6` + `claude-sonnet-4-6` quad).
 
 Each explorer returns file pointers, conventions, dependencies, test infrastructure, and entry points. No inlined dumps.
 

--- a/plugins/pstack/skills/setup-pstack/SKILL.md
+++ b/plugins/pstack/skills/setup-pstack/SKILL.md
@@ -21,7 +21,7 @@ so the file is loaded as context for every session.
 
 ### 1. Detect available models
 
-Enumerate the model slugs you can pass to an `Agent` subagent in this session — that is the dependable source. Claude family currently available: Opus 4.8 (`claude-opus-4-8`), Opus 4.6 (`claude-opus-4-6`), Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5`). The default panels pair `4-8` with `4-6` for cross-generation diversity inside the opus tier. Ask the user to confirm or paste any additional slugs they want available. Never write a slug you have not confirmed is available.
+Enumerate the model slugs you can pass to an `Agent` subagent in this session — that is the dependable source. Claude family currently available: Opus 4.8 (`claude-opus-4-8`), Opus 4.6 (`claude-opus-4-6`), Sonnet 5 (`claude-sonnet-5`), Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5`). The default panels run both opus generations (`4-8`, `4-6`) and both sonnet generations (`5`, `4-6`) for cross-generation, cross-tier diversity. Ask the user to confirm or paste any additional slugs they want available. Never write a slug you have not confirmed is available.
 
 ### 2. Load current state
 
@@ -51,14 +51,14 @@ hillclimb: claude-opus-4-8
 judgment and prose: claude-opus-4-8
 how explorer: claude-opus-4-8
 how explainer: claude-opus-4-8
-how critics: claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6
+how critics: claude-opus-4-8, claude-sonnet-5, claude-opus-4-6, claude-sonnet-4-6
 why investigators: claude-opus-4-8
 why synthesizer: claude-opus-4-8
 reflect tooling: claude-opus-4-8
 reflect judgment, divergent, synthesizer: claude-opus-4-8
-arena runners: claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6
-architect runners: claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6
-interrogate reviewers: claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6
+arena runners: claude-opus-4-8, claude-sonnet-5, claude-opus-4-6, claude-sonnet-4-6
+architect runners: claude-opus-4-8, claude-sonnet-5, claude-opus-4-6, claude-sonnet-4-6
+interrogate reviewers: claude-opus-4-8, claude-sonnet-5, claude-opus-4-6, claude-sonnet-4-6
 ```
 
 ### 6. Wire it in


### PR DESCRIPTION
Grows the `arena` / `architect` / `interrogate` / `how`-critics panels from a triple to a quad: `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-sonnet-4-6` — both generations in each of two tiers. This also restores upstream's four-way `interrogate` split; the port had been running three reviewers under a "four different models" description.

`setup-pstack` adds Sonnet 5 (`claude-sonnet-5`) to the available-family enumeration and the four panel rows of its default sheet. Single-model delegation defaults stay `claude-opus-4-8`. Historical Cursor→Claude mapping rows in the README table are unchanged — they record what the 0.9.2 sync substituted, not current defaults.

Bump 0.9.3 → 0.9.4 across all three version-bearing manifests. `claude plugin validate` passes.