### PR TITLE
fix: collapse session-start to plain stdout; trim quad duplication (review)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pstack",
       "source": "./plugins/pstack",
       "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "author": {
         "name": "Lauren Tan (original)"
       },

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 This port applies the Cursor → Claude Code substitutions in skill bodies. Earlier drafts left them flagged; this revision resolves them. A later pass added a Codex build that shares the same skills; see [Codex port](#codex-port) below.
 
+## 0.9.6 — hook hardening and duplication trims (thermo-nuclear review)
+
+A strict maintainability review of the 0.9.3–0.9.5 range drove these:
+
+- `hooks/session-start` collapsed from 43 lines to 3: SessionStart hook stdout reaches context directly (per the hooks docs; verified end-to-end on 2.1.197), so the JSON envelope, the `escape_for_json` pass, and the Cursor/Copilot platform branches — dead code here, since `hooks.json` is the only registration — are gone. This also removes a verified failure-path bug: the old `cat ... 2>&1 || echo` fallback was additive, silently injecting raw `cat` stderr plus the fallback string into session context when the context file was unreadable; now a missing file fails the hook cleanly and injects nothing. The script is no longer adapted from superpowers (NOTICE updated; `run-hook.cmd` remains near-verbatim and attributed).
+- Panel-quad enumeration trimmed from the `poteto-mode` meta-files (`SKILL.md`, `references/plan.md`, `references/codex-tools.md`) — the slugs now live only in the four panel skills and the `setup-pstack` sheet, with a grep-identical rule added to Maintenance. This drift class already bit once (0.9.4 fixed a three-reviewers-vs-"four different models" mismatch).
+- README's desktop-app `dependency-unsatisfied` narrative deduplicated to a two-sentence summary linking the CHANGES 0.9.3 entry.
+
 ## Upstream review through `0452e08` (v0.10.0), 2026-07-01
 
 One upstream pstack commit landed after the `e46364b` sync: `0452e08` adds the dormant `automations/benny/` pack (Slack issue triage plus reproduce-and-fix, built on Cursor's event-triggered automations) and bumps upstream to 0.10.0. Deliberately not ported — rationale and revisit criteria in README → What's deliberately not ported. `cursor-team-kit` has no commits since the sync point (its latest, `679fdaf`, 2026-05-28, predates `e46364b`). The port's skill tree therefore matches upstream HEAD for every registered skill.
@@ -44,7 +52,7 @@ pstack diverges from superpowers in one respect, and it is deliberate. superpowe
 
 **Verified.** Codex discovers the skills and namespaces them under `pstack` (`pstack:poteto-mode` and so on) in a live session. Mapping resolution mid-task and `spawn_agent` fan-out follow the `superpowers` pattern and are worth confirming per session.
 
-**Maintenance.** The plugin version string now lives in three manifests: `plugins/pstack/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `plugins/pstack/.codex-plugin/plugin.json`. A version bump must update all three. `.agents/plugins/marketplace.json` carries no version field.
+**Maintenance.** The plugin version string now lives in three manifests: `plugins/pstack/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `plugins/pstack/.codex-plugin/plugin.json`. A version bump must update all three. `.agents/plugins/marketplace.json` carries no version field. The default panel quad is enumerated only in the four panel skills (`arena`, `architect`, `how`, `interrogate`) and the `setup-pstack` sheet — keep those lines grep-identical when models change; `poteto-mode` and its references deliberately do not enumerate it. `hooks/session-start-context.md` restates skill one-liners — re-verify it whenever skill names or descriptions change.
 
 ## 0.9.2 sync (against upstream `e46364b`)
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -13,7 +13,7 @@ This plugin is a port of upstream MIT-licensed work. All upstream copyright noti
 | `plugins/pstack/skills/fix-ci/` | [cursor/plugins/cursor-team-kit/skills/fix-ci @ e46364b](https://github.com/cursor/plugins/tree/e46364b8be46000b7df0f260550cd712afbb8d36/cursor-team-kit/skills/fix-ci) | (c) 2026 Cursor | MIT | [LICENSE-cursor-team-kit](LICENSE-cursor-team-kit) |
 | `plugins/pstack/skills/fix-merge-conflicts/` | [cursor/plugins/cursor-team-kit/skills/fix-merge-conflicts @ e46364b](https://github.com/cursor/plugins/tree/e46364b8be46000b7df0f260550cd712afbb8d36/cursor-team-kit/skills/fix-merge-conflicts) | (c) 2026 Cursor | MIT | [LICENSE-cursor-team-kit](LICENSE-cursor-team-kit) |
 | `plugins/pstack/skills/get-pr-comments/` | [cursor/plugins/cursor-team-kit/skills/get-pr-comments @ e46364b](https://github.com/cursor/plugins/tree/e46364b8be46000b7df0f260550cd712afbb8d36/cursor-team-kit/skills/get-pr-comments) | (c) 2026 Cursor | MIT | [LICENSE-cursor-team-kit](LICENSE-cursor-team-kit) |
-| `plugins/pstack/hooks/run-hook.cmd` (near-verbatim), `plugins/pstack/hooks/session-start` (JSON-emission pattern adapted) | [anthropics/claude-plugins-official → superpowers @ 6.1.0](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/superpowers) (originally obra/superpowers) | (c) 2025 Jesse Vincent | MIT | [LICENSE-superpowers](LICENSE-superpowers) |
+| `plugins/pstack/hooks/run-hook.cmd` (near-verbatim) | [anthropics/claude-plugins-official → superpowers @ 6.1.0](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/superpowers) (originally obra/superpowers) | (c) 2025 Jesse Vincent | MIT | [LICENSE-superpowers](LICENSE-superpowers) |
 | `plugins/pstack/skills/what-did-i-get-done/` | [cursor/plugins/cursor-team-kit/skills/what-did-i-get-done @ e46364b](https://github.com/cursor/plugins/tree/e46364b8be46000b7df0f260550cd712afbb8d36/cursor-team-kit/skills/what-did-i-get-done) | (c) 2026 Cursor | MIT | [LICENSE-cursor-team-kit](LICENSE-cursor-team-kit) |
 
 ## What changed in the port
@@ -42,7 +42,7 @@ Files authored for this port (not derived from upstream):
 - `plugins/pstack/skills/poteto-mode/references/codex-tools.md`
 - `plugins/pstack/commands/*.md`
 - `plugins/pstack/skills/babysit/SKILL.md` (independently authored; workflow informed by Cursor's public `/babysit` behavior)
-- `plugins/pstack/hooks/hooks.json` and `plugins/pstack/hooks/session-start-context.md` (the auto-fire mandate)
+- `plugins/pstack/hooks/hooks.json`, `plugins/pstack/hooks/session-start`, and `plugins/pstack/hooks/session-start-context.md` (the auto-fire hook and its mandate)
 - `NOTICE.md` (this file)
 - `README.md`
 - `CHANGES.md`

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Nothing is declared in `plugin.json`. Install the one companion plugin yourself:
   /plugin install plugin-dev@claude-plugins-official
   ```
 
-  Until 0.9.2 this was a `dependencies` entry in `plugin.json`, auto-resolved on marketplace install. The Claude Code desktop app, however, passes every plugin to the CLI as a session-only `--plugin-dir`, which strips marketplace identity (the plugin becomes `pstack@inline`). A cross-marketplace dependency can never resolve in that mode, so the loader disabled the whole plugin with `dependency-unsatisfied` — pstack silently vanished from every desktop-app session while working in the CLI and VS Code. `optional: true` on a dependency entry validates but is not honored (tested on 2.1.197), so 0.9.3 demotes the dependency to documentation. Without `plugin-dev` installed, only the skill-authoring routes degrade; everything else works.
+  Until 0.9.2 this was a `dependencies` entry in `plugin.json`. The desktop app's `--plugin-dir` load mode can never resolve cross-marketplace dependencies and hard-disables the whole plugin, so 0.9.3 removed the declaration — full mechanism in the 0.9.3 entry of [CHANGES.md](CHANGES.md). Without `plugin-dev` installed, only the skill-authoring routes degrade; everything else works.
 
 Not declared as deps, but referenced in skill bodies:
 
@@ -195,4 +195,4 @@ MIT. Three upstream LICENSE files are preserved:
 
 - [LICENSE](LICENSE) — pstack (Lauren Tan)
 - [LICENSE-cursor-team-kit](LICENSE-cursor-team-kit) — Cursor (covers the `deslop` and `thermo-nuclear-code-quality-review` skills)
-- [LICENSE-superpowers](LICENSE-superpowers) — superpowers, Jesse Vincent (covers the adapted `hooks/run-hook.cmd` and the `hooks/session-start` emission pattern)
+- [LICENSE-superpowers](LICENSE-superpowers) — superpowers, Jesse Vincent (covers the vendored `hooks/run-hook.cmd`)

--- a/plugins/pstack/.claude-plugin/plugin.json
+++ b/plugins/pstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pstack",
   "displayName": "pstack (Claude Code port)",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Ported from cursor/plugins/pstack to Claude Code.",
   "author": {
     "name": "Lauren Tan"

--- a/plugins/pstack/.codex-plugin/plugin.json
+++ b/plugins/pstack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pstack",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Codex port of the Claude Code plugin; skills are shared, tool names resolve via skills/poteto-mode/references/codex-tools.md.",
   "author": {
     "name": "Lauren Tan"

--- a/plugins/pstack/hooks/session-start
+++ b/plugins/pstack/hooks/session-start
@@ -1,43 +1,8 @@
 #!/usr/bin/env bash
-# SessionStart hook for the pstack plugin: injects the poteto-mode dispatch
-# mandate as additional context. JSON-emission pattern adapted from the
-# superpowers plugin (MIT); see NOTICE.md and LICENSE-superpowers.
+# SessionStart hook for the pstack plugin: prints the poteto-mode dispatch
+# mandate to stdout, which Claude Code injects as session context directly.
+# A missing context file fails the hook cleanly instead of injecting noise.
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-
-context_body=$(cat "${PLUGIN_ROOT}/hooks/session-start-context.md" 2>&1 || echo "Error reading pstack session-start context")
-
-# Escape string for JSON embedding using bash parameter substitution.
-# Each ${s//old/new} is a single C-level pass.
-escape_for_json() {
-    local s="$1"
-    s="${s//\\/\\\\}"
-    s="${s//\"/\\\"}"
-    s="${s//$'\n'/\\n}"
-    s="${s//$'\r'/\\r}"
-    s="${s//$'\t'/\\t}"
-    printf '%s' "$s"
-}
-
-session_context=$(escape_for_json "$context_body")
-
-# Output context injection as JSON.
-# Cursor hooks expect additional_context (snake_case).
-# Claude Code hooks expect hookSpecificOutput.additionalContext (nested).
-# Copilot CLI (v1.0.11+) and others expect additionalContext (top-level).
-# Emit only the field the current platform consumes.
-#
-# Uses printf instead of heredoc to work around a bash 5.3+ heredoc hang
-# (obra/superpowers#571).
-if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
-  printf '{\n  "additional_context": "%s"\n}\n' "$session_context" | cat
-elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
-  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context" | cat
-else
-  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context" | cat
-fi
-
-exit 0
+exec cat "$(cd "$(dirname "$0")" && pwd)/session-start-context.md"

--- a/plugins/pstack/skills/poteto-mode/SKILL.md
+++ b/plugins/pstack/skills/poteto-mode/SKILL.md
@@ -83,7 +83,7 @@ Read the leaf skill in full for any principle you apply. Each entry names when i
 
 **Use `subagent_type: "poteto-agent"` for any subagent you spawn inside a playbook step** (code-writing delegates, ad-hoc helpers). `/poteto-mode` and `poteto-agent` route through the same wrapper. Routed workflow skills (`how`, `why`, `interrogate`, `reflect`) set their own `subagent_type` for diverse-model review; respect what the skill prescribes, don't override to `poteto-agent`.
 
-**Defaults for every `Agent` call.** `run_in_background: true`, full tool access (do not pick a subagent_type that strips MCP), file pointers not inlined context, explicit model per role (configurable via `/setup-pstack`; default `claude-opus-4-8` for code-writing delegations, prose, and judgment; multi-model panels run the `claude-opus-4-8` + `claude-sonnet-5` + `claude-opus-4-6` + `claude-sonnet-4-6` quad for diversity).
+**Defaults for every `Agent` call.** `run_in_background: true`, full tool access (do not pick a subagent_type that strips MCP), file pointers not inlined context, explicit model per role (configurable via `/setup-pstack`; default `claude-opus-4-8` for code-writing delegations, prose, and judgment; multi-model panels run the configured four-model quad for diversity — defaults enumerated in the panel skills (`arena`, `architect`, `interrogate`, `how`), overridden via `/setup-pstack`).
 
 You own every subagent's work. Review the diff and write your own summary, don't pass through what it said. Interrupt-chained resumes silently drop directives, so fire a fresh subagent with consolidated scope rather than trusting a "done" summary. A second opinion is the same prompt against a different model. Agreement is high-signal.
 

--- a/plugins/pstack/skills/poteto-mode/references/codex-tools.md
+++ b/plugins/pstack/skills/poteto-mode/references/codex-tools.md
@@ -39,7 +39,7 @@ poteto-mode's Subagents section sets Claude-specific defaults (`subagent_type: "
 
 ## Model names
 
-Skills name Claude defaults (`claude-opus-4-8` for code/prose/judgment; the `claude-opus-4-8` + `claude-sonnet-5` + `claude-opus-4-6` + `claude-sonnet-4-6` quad for diverse-model panels). These slugs do not resolve on Codex. Substitute your configured Codex models:
+Skills name Claude defaults (`claude-opus-4-8` for code/prose/judgment; a four-model quad for diverse-model panels, enumerated in the panel skills). These slugs do not resolve on Codex. Substitute your configured Codex models:
 
 - Single-model roles: your primary Codex model (for example `gpt-5.5`).
 - Diverse-model panels (`interrogate`, `how` critics, `reflect`): the adversarial signal comes from model diversity, so use the distinct Codex models available to you. If only one model family is reachable, vary reasoning effort and note in the verdict that diversity was reduced.

--- a/plugins/pstack/skills/poteto-mode/references/plan.md
+++ b/plugins/pstack/skills/poteto-mode/references/plan.md
@@ -25,7 +25,7 @@ Resolve what is in scope vs explicitly out, technical or platform constraints, p
 Delegate codebase exploration (the **guard-the-context-window** principle skill).
 
 - Prefer `subagent_type: "poteto-agent"`. `general-purpose` is the fallback. Never use Claude Code's built-in `Plan` agent; it ignores this skill.
-- Pass `model:` explicitly per the configured roles (default `claude-opus-4-8` for code-writing delegations and judgment; multi-model panels run the `claude-opus-4-8` + `claude-sonnet-5` + `claude-opus-4-6` + `claude-sonnet-4-6` quad).
+- Pass `model:` explicitly per the configured roles (default `claude-opus-4-8` for code-writing delegations and judgment; multi-model panels run the configured quad — defaults in the panel skills, overridden via `/setup-pstack`).
 
 Each explorer returns file pointers, conventions, dependencies, test infrastructure, and entry points. No inlined dumps.
 


### PR DESCRIPTION
Applies the thermo-nuclear review of the 0.9.3–0.9.5 range.

**Required (Findings 1–2):** `hooks/session-start` collapses from 43 lines to 3 — SessionStart stdout reaches context directly (verified end-to-end on 2.1.197 via the desktop bundle's binary), killing the JSON envelope, escape pass, and the dead Cursor/Copilot branches. Also fixes the verified failure-path bug: the additive `2>&1 || echo` fallback injected raw `cat` stderr plus the fallback string into session context; a missing context file now fails the hook cleanly — debug log shows the error in hook diagnostics with nothing injected (both paths re-verified).

**Strongly requested (Findings 3, 8):** panel-quad slugs now enumerated only in the four panel skills + the `setup-pstack` sheet, with a grep-identical Maintenance rule; README's desktop-app narrative deduplicated to a summary linking CHANGES 0.9.3.

NOTICE/LICENSE bookkeeping: `session-start` is no longer superpowers-derived; `run-hook.cmd` remains near-verbatim and attributed. Bump 0.9.5 → 0.9.6.