### PR TITLE
fix: keep invariant checks from aborting under set -e on grep no-match

### DIFF
--- a/tests/skill-collision-repro.sh
+++ b/tests/skill-collision-repro.sh
@@ -69,7 +69,7 @@ fi
 
 # Static invariant (CHANGES maintenance note): the plugin version string is
 # duplicated across three manifests and must move together on a bump.
-verof() { grep -m1 '"version"' "$1" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'; }
+verof() { { grep -m1 '"version"' "$1" || true; } | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'; }
 vc="$(verof "$repo/plugins/pstack/.claude-plugin/plugin.json")"
 vx="$(verof "$repo/plugins/pstack/.codex-plugin/plugin.json")"
 vm="$(verof "$repo/.claude-plugin/marketplace.json")"
@@ -87,14 +87,14 @@ fi
 # drifting silently. (This copy in the test is the assertion anchor; a single generated
 # source for the quad would retire all of them, this check included.)
 setup="$repo/plugins/pstack/skills/setup-pstack/SKILL.md"
-quad_of() { grep -oE 'claude-[a-z0-9-]+' | tr '\n' ' ' | sed 's/ $//'; }
-canon_quad="$(grep -m1 '^arena runners:' "$setup" | quad_of)"
+quad_of() { { grep -oE 'claude-[a-z0-9-]+' || true; } | tr '\n' ' ' | sed 's/ $//'; }
+canon_quad="$(grep -m1 '^arena runners:' "$setup" | quad_of || true)"
 quad_bad=""
 [ -n "$canon_quad" ] || quad_bad="could not read the canonical quad from $setup (arena runners row)"$'\n'
 # Each panel skill states the quad on its one line naming the fourth slug.
 for name in arena architect how interrogate; do
   skill="$repo/plugins/pstack/skills/$name/SKILL.md"
-  n="$(grep -Fc 'claude-sonnet-4-6' "$skill")"
+  n="$(grep -Fc 'claude-sonnet-4-6' "$skill" || true)"
   if [ "$n" != "1" ]; then
     quad_bad="$quad_bad$skill: expected exactly 1 default-quad line, found $n"$'\n'
     continue


### PR DESCRIPTION
## The bug

The version and quad checks added in #12 run `grep` inside command substitutions without guarding its exit-1-on-no-match. Under `set -euo pipefail`, that aborts the whole script.

The reachable case: a skill loses its quad line entirely (a model rename/removal). `n="$(grep -Fc 'claude-sonnet-4-6' "$skill")"` returns count `0` **and exit 1**, so `set -e` kills the script *before* the intended `expected exactly 1 default-quad line, found 0` message prints. The maintainer sees a bare exit 1 with no indication of which skill drifted — the opposite of a useful check.

#12's negative test missed this because it mutated a non-fourth slug, leaving `claude-sonnet-4-6` present (so `grep` still matched, exit 0). Reproduced by deleting a skill's quad line: pre-fix the script aborts with no quad message; the "found 0" branch was unreachable.

## The fix

Match how the pre-existing checks already handle grep's exit code (`|| true` on line 23; `&&`/`||` on the principle check):

- Make `verof` and `quad_of` self-guarding: `{ grep ... || true; } | ...`
- Guard the two standalone greps (`canon_quad`, `n`) with `|| true`

Three lines. No behavior change on matching input.

## Testing (static checks, no CLI)

- **Baseline** — all pass, exit 0.
- **Quad line removed** (the bug) — now `FAIL: ... interrogate ...: expected exactly 1 default-quad line, found 0`, exit 1. No abort.
- **Missing `arena runners:` row** — graceful `could not read the canonical quad`, exit 1.
- **Version drift** — `FAIL: ... marketplace=0.9.11`, exit 1 (unchanged).
- **Slug drift** — `FAIL` naming the file and the mismatched sequence (unchanged).
- `bash -n` clean.