### PR TITLE
feat: swap claude-opus-4-6 for claude-fable-5 in the default panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The port is editorial, not mechanical. Anywhere upstream pstack assumed Cursor-s
 | Model `composer-2.5-fast` (Cursor) | `claude-sonnet-4-6` |
 | Model `claude-opus-4-X-thinking-xhigh` (Cursor UI variant) | `claude-opus-4-8` (extended thinking configured separately) |
 | Models `gpt-5.3-codex-high-fast`, `gpt-5.5-high-fast` (via Cursor) | `claude-sonnet-4-6`, `claude-haiku-4-5` (Claude family) |
-| Multi-model panels (arena, architect, interrogate, how-critics) | Default quad is `claude-opus-4-8` + `claude-sonnet-5` + `claude-opus-4-6` + `claude-sonnet-4-6` — four distinct models across two generations and two tiers (replaces the cross-vendor diversity lost in translation and restores upstream's four-way split). |
+| Multi-model panels (arena, architect, interrogate, how-critics) | Default quad is `claude-opus-4-8` + `claude-sonnet-5` + `claude-fable-5` + `claude-sonnet-4-6` — four distinct models across three families (replaces the cross-vendor diversity lost in translation and restores upstream's four-way split). |
 
 ### What's lost in translation
 

--- a/plugins/pstack/skills/architect/SKILL.md
+++ b/plugins/pstack/skills/architect/SKILL.md
@@ -31,7 +31,7 @@ Skip Phase A only when the work is genuinely greenfield with no surrounding syst
 
 Run the **arena** skill with the design-sketch task and the Phase A grounding artifacts. Pass `references/runner-prompt.md` as each runner's prompt. Each candidate produces a design package shaped per `references/rationale-template.md`: the caller's usage written first, then the type sketch, function signatures, module map, and prose rationale derived from it.
 
-Use your configured architect runners (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-sonnet-4-6`).
+Use your configured architect runners (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-sonnet-4-6`).
 
 This is the **exhaust-the-design-space** principle skill made concrete. Whole-shape alternatives, not point fixes inside one shape.
 

--- a/plugins/pstack/skills/arena/SKILL.md
+++ b/plugins/pstack/skills/arena/SKILL.md
@@ -26,7 +26,7 @@ The N candidates will receive the same prompt, so the prompt is the contract. Ge
 
 1. State the artifact each candidate is producing.
 2. Derive the rubric. State what success looks like for *this* task, then turn it into 3-6 concrete gradeable criteria. Concrete: `Adds a --dry-run flag that skips writes`. Vague: `code is correct`. The rubric is the picker's tool in Phase D; candidates only see the task.
-3. Pick the runners. Default runners are your configured arena list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-sonnet-4-6`). Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
+3. Pick the runners. Default runners are your configured arena list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-sonnet-4-6`). Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
 4. Assign output paths. Each candidate writes to its own location (a git worktree where possible, otherwise `/tmp/arena-<slug>/candidate-<n>/`). N candidates writing to the same path is shared mutable state and fails the the **separate-before-serializing-shared-state** principle skill test.
 
 ## Phase B: Fan out

--- a/plugins/pstack/skills/how/SKILL.md
+++ b/plugins/pstack/skills/how/SKILL.md
@@ -111,7 +111,7 @@ Run the full explain flow above (Steps 1-4). You must understand the architectur
 
 ### Step 2. Spawn Critics
 
-After the explanation is complete, spawn one architectural critic per model in your configured how-critics list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-sonnet-4-6`), all in a single message.
+After the explanation is complete, spawn one architectural critic per model in your configured how-critics list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-sonnet-4-6`), all in a single message.
 
 For each critic:
 - `subagent_type`: `general-purpose`

--- a/plugins/pstack/skills/interrogate/SKILL.md
+++ b/plugins/pstack/skills/interrogate/SKILL.md
@@ -34,7 +34,7 @@ Write one clear paragraph. Reviewers challenge whether the work achieves the int
 
 ## Step 3, Spawn Reviewers
 
-Launch one reviewer per model in your configured interrogate list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-sonnet-4-6`), all in a single message.
+Launch one reviewer per model in your configured interrogate list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-sonnet-4-6`), all in a single message.
 
 For each reviewer:
 - `subagent_type`: `general-purpose`

--- a/plugins/pstack/skills/setup-pstack/SKILL.md
+++ b/plugins/pstack/skills/setup-pstack/SKILL.md
@@ -21,7 +21,7 @@ so the file is loaded as context for every session.
 
 ### 1. Detect available models
 
-Enumerate the model slugs you can pass to an `Agent` subagent in this session — that is the dependable source. Claude family currently available: Opus 4.8 (`claude-opus-4-8`), Opus 4.6 (`claude-opus-4-6`), Sonnet 5 (`claude-sonnet-5`), Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5`). The default panels run both opus generations (`4-8`, `4-6`) and both sonnet generations (`5`, `4-6`) for cross-generation, cross-tier diversity. Ask the user to confirm or paste any additional slugs they want available. Never write a slug you have not confirmed is available.
+Enumerate the model slugs you can pass to an `Agent` subagent in this session — that is the dependable source. Claude family currently available: Opus 4.8 (`claude-opus-4-8`), Fable 5 (`claude-fable-5`), Sonnet 5 (`claude-sonnet-5`), Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5`). The default panels run Opus 4.8 (`claude-opus-4-8`), Fable 5 (`claude-fable-5`), and both sonnet generations (`5`, `4-6`) for cross-family, cross-tier diversity. Ask the user to confirm or paste any additional slugs they want available. Never write a slug you have not confirmed is available.
 
 ### 2. Load current state
 
@@ -51,15 +51,15 @@ hillclimb: claude-opus-4-8
 judgment and prose: claude-opus-4-8
 how explorer: claude-opus-4-8
 how explainer: claude-opus-4-8
-how critics: claude-opus-4-8, claude-sonnet-5, claude-opus-4-6, claude-sonnet-4-6
+how critics: claude-opus-4-8, claude-sonnet-5, claude-fable-5, claude-sonnet-4-6
 why investigators: claude-opus-4-8
 why synthesizer: claude-opus-4-8
 reflect tooling: claude-opus-4-8
 reflect judgment, divergent, synthesizer: claude-opus-4-8
-arena runners: claude-opus-4-8, claude-sonnet-5, claude-opus-4-6, claude-sonnet-4-6
-arena cross-judge pool: claude-opus-4-8, claude-sonnet-5, claude-opus-4-6
-architect runners: claude-opus-4-8, claude-sonnet-5, claude-opus-4-6, claude-sonnet-4-6
-interrogate reviewers: claude-opus-4-8, claude-sonnet-5, claude-opus-4-6, claude-sonnet-4-6
+arena runners: claude-opus-4-8, claude-sonnet-5, claude-fable-5, claude-sonnet-4-6
+arena cross-judge pool: claude-opus-4-8, claude-sonnet-5, claude-fable-5
+architect runners: claude-opus-4-8, claude-sonnet-5, claude-fable-5, claude-sonnet-4-6
+interrogate reviewers: claude-opus-4-8, claude-sonnet-5, claude-fable-5, claude-sonnet-4-6
 ```
 
 ### 6. Wire it in


### PR DESCRIPTION
## What

Replaces `claude-opus-4-6` with `claude-fable-5` everywhere it is a live default-panel model reference:

- The four panel skills: `arena`, `architect`, `how` (critics), `interrogate` — the default quad line.
- `setup-pstack`: the four panel role rows, the `arena cross-judge pool` triple, the "currently available" list, and the rationale prose.
- `README.md`: the substitution-table quad row.

New quad: `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-sonnet-4-6` — now spanning three model families (opus, sonnet, fable) instead of two opus generations plus two sonnet generations. The rationale prose changes from "both opus generations … cross-generation" to "cross-family" to stay accurate.

`claude-fable-5` is already an established slug here — `poteto-mode` delegates its hardest code changes to it as the strongest-judgment model — so this adds it to the panels rather than introducing a new model.

## Verified

- `tests/skill-collision-repro.sh` passes: the quad is identical across all four panel skills and the `setup-pstack` sheet, and version parity holds.
- No `claude-opus-4-6` remains anywhere except the historical `CHANGES.md` entries (a record of past changes, deliberately untouched).

## Notes / choices to confirm

- **`claude-opus-4-6` is fully dropped from the roster**, including the `setup-pstack` "available models" list. If you'd rather keep it selectable (just out of the default panels), say so and I'll re-add it there.
- **No version bump or CHANGES.md entry.** This is a behavior change to the defaults, so it would normally warrant a `0.9.11` entry + a bump across the three manifests. I held off — tell me to add it and I'll bump all three (the version-parity check will confirm).