### PR TITLE
docs: add a suggested OpenAI panel quad for the Codex build

### DIFF
--- a/plugins/pstack/skills/poteto-mode/references/codex-tools.md
+++ b/plugins/pstack/skills/poteto-mode/references/codex-tools.md
@@ -41,8 +41,8 @@ poteto-mode's Subagents section sets Claude-specific defaults (`subagent_type: "
 
 Skills name Claude defaults (`claude-opus-4-8` for code/prose/judgment; a four-model quad for diverse-model panels, enumerated in the panel skills). These slugs do not resolve on Codex. Substitute your configured Codex models:
 
-- Single-model roles: your primary Codex model (for example `gpt-5.5`).
-- Diverse-model panels (`interrogate`, `how` critics, `reflect`): the adversarial signal comes from model diversity, so use the distinct Codex models available to you. If only one model family is reachable, vary reasoning effort and note in the verdict that diversity was reduced.
+- Single-model roles: your primary Codex model (for example `gpt-5.6-sol`).
+- Diverse-model panels (`arena`, `architect`, `interrogate`, `how` critics, `reflect`): the adversarial signal comes from model diversity, so use the distinct Codex models available to you. A good default quad on ChatGPT is `gpt-5.6-sol`, `gpt-5.5`, `gpt-5.4`, `gpt-5.6-luna`. If only one model family is reachable, vary reasoning effort and note in the verdict that diversity was reduced.
 
 `/setup-pstack` writes the configured model list. On Codex, set it to your Codex model slugs.
 


### PR DESCRIPTION
## What

[codex-tools.md](plugins/pstack/skills/poteto-mode/references/codex-tools.md) told Codex users to "substitute your configured Codex models" but never named a concrete diverse-model panel set. On ChatGPT that left the panels' diversity undefined — with one model they collapse to a single reviewer.

Names a suggested default quad: `gpt-5.6-sol`, `gpt-5.5`, `gpt-5.4`, `gpt-5.6-luna` — four distinct models, the same cross-model diversity the Claude quad provides. Also updates the single-model example to `gpt-5.6-sol` and adds `arena`/`architect` to the diverse-panel list (they run the quad too).

Written as a **suggested default, not a mandate** — `setup-pstack` still detects each user's own Codex slugs from `~/.codex/config.toml`.

## Notes

- Slugs verified against a live Codex `models_cache.json`, all four present.
- The Claude-side panel skills are untouched; they use `claude-*` slugs on both runtimes by design. This keeps the Claude quad and the Codex quad each in one place.