### PR TITLE
Tighten poteto-mode reply format

### DIFF
--- a/plugins/pstack/skills/poteto-mode/SKILL.md
+++ b/plugins/pstack/skills/poteto-mode/SKILL.md
@@ -11,7 +11,7 @@ These skills use Claude Code tool names (the `Skill` tool, the `Agent` tool, `As
 
 ## Non-negotiables
 
-**Start every multi-step task with a todolist whose first item is to read the Principles section below in full.** The principles ground every trigger here. In your reply, name the principles that shaped decisions and the choice each changed. A clause per principle, not a paragraph. A citation with no decision behind it means you skipped its leaf skill; it must trace to a real choice the leaf's rule drove.
+**Start every multi-step task with a todolist whose first item is to read the Principles section below in full.** The principles ground every trigger here. In your reply, name the principles that shaped decisions and the choice each changed. A sentence per principle carries both; the justification stays in the work, not the reply. A citation with no decision behind it means you skipped its leaf skill; it must trace to a real choice the leaf's rule drove.
 
 Remaining triggers:
 
@@ -94,7 +94,7 @@ Write the reply clean as you draft it. The cleanup-afterward pass has been measu
 - **Short declarative sentences.** One thought per sentence, ended with a period.
 - **The long-dash character is banned outright.** Two cases. A file-list bullet joining a filename to its description with a dash. Write it as a sentence ("`main.js` owns persistence and the IPC handlers"). A bold section header joined to its text by a dash. Write the header as its own sentence ("**Verification.** End to end via CDP").
 - **A colon as a mid-sentence connector is also out** (unslop rule 14). A colon before a list is fine.
-- **Terse is not an excuse to drop content.** Every item the playbook's reply names stays. Render each as a sentence or two of prose. No section headers, and no item expanded into its own block.
+- **Terse is not an excuse to drop content.** Every item the playbook's reply names stays. Render each as prose, usually a sentence or two, longer when the content needs it. No section headers, and no item expanded into its own block.
 - **Frame impact for the consumer and the maintainer.** Name who the work is for (an end user, a colleague importing the library) and what changes for them before any implementation detail. Then what the next engineer who owns this code inherits. If you can't say what either would notice, the work or the explanation is off.
 - **Never fabricate a link, citation, or transcript reference.** Link only artifacts you produced or read this session.
 

--- a/plugins/pstack/skills/poteto-mode/SKILL.md
+++ b/plugins/pstack/skills/poteto-mode/SKILL.md
@@ -11,7 +11,7 @@ These skills use Claude Code tool names (the `Skill` tool, the `Agent` tool, `As
 
 ## Non-negotiables
 
-**Start every multi-step task with a todolist whose first item is to read the Principles section below in full.** The principles ground every trigger here. In your reply, name the principles that shaped decisions and the choice each changed, in one line total. A citation with no decision behind it means you skipped its leaf skill; it must trace to a real choice the leaf's rule drove.
+**Start every multi-step task with a todolist whose first item is to read the Principles section below in full.** The principles ground every trigger here. In your reply, name the principles that shaped decisions and the choice each changed. A clause per principle, not a paragraph. A citation with no decision behind it means you skipped its leaf skill; it must trace to a real choice the leaf's rule drove.
 
 Remaining triggers:
 

--- a/plugins/pstack/skills/poteto-mode/SKILL.md
+++ b/plugins/pstack/skills/poteto-mode/SKILL.md
@@ -11,7 +11,7 @@ These skills use Claude Code tool names (the `Skill` tool, the `Agent` tool, `As
 
 ## Non-negotiables
 
-**Start every multi-step task with a todolist whose first item is to read the Principles section below in full.** The principles ground every trigger here. In your reply, name each principle that shaped a decision and the specific choice it changed. A citation with no decision behind it means you skipped its leaf skill; it must trace to a real choice the leaf's rule drove.
+**Start every multi-step task with a todolist whose first item is to read the Principles section below in full.** The principles ground every trigger here. In your reply, name the principles that shaped decisions and the choice each changed, in one line total. A citation with no decision behind it means you skipped its leaf skill; it must trace to a real choice the leaf's rule drove.
 
 Remaining triggers:
 
@@ -94,7 +94,7 @@ Write the reply clean as you draft it. The cleanup-afterward pass has been measu
 - **Short declarative sentences.** One thought per sentence, ended with a period.
 - **The long-dash character is banned outright.** Two cases. A file-list bullet joining a filename to its description with a dash. Write it as a sentence ("`main.js` owns persistence and the IPC handlers"). A bold section header joined to its text by a dash. Write the header as its own sentence ("**Verification.** End to end via CDP").
 - **A colon as a mid-sentence connector is also out** (unslop rule 14). A colon before a list is fine.
-- **Terse is not an excuse to drop content.** Short sentences, but every section the playbook's reply names stays: details, tradeoffs, choices, open decisions.
+- **Terse is not an excuse to drop content.** Every item the playbook's reply names stays. Render each as a sentence or two of prose. No section headers, and no item expanded into its own block.
 - **Frame impact for the consumer and the maintainer.** Name who the work is for (an end user, a colleague importing the library) and what changes for them before any implementation detail. Then what the next engineer who owns this code inherits. If you can't say what either would notice, the work or the explanation is off.
 - **Never fabricate a link, citation, or transcript reference.** Link only artifacts you produced or read this session.
 

--- a/plugins/pstack/skills/poteto-mode/playbooks/bug-fix.md
+++ b/plugins/pstack/skills/poteto-mode/playbooks/bug-fix.md
@@ -14,4 +14,4 @@ Be scientific. Every shipped line traces to runtime evidence. Belt-and-suspender
 
 Investigation fans out `how` + `why` as parallel subagents.
 
-**Reply:** what was broken, root cause, fix, how you verified. Paste failing-then-passing repro output verbatim.
+**Reply:** what was broken, root cause, fix, how you verified. Quote the decisive failing line and the decisive passing line, trimmed to the assertion and the counts.

--- a/plugins/pstack/skills/poteto-mode/playbooks/bug-fix.md
+++ b/plugins/pstack/skills/poteto-mode/playbooks/bug-fix.md
@@ -14,4 +14,4 @@ Be scientific. Every shipped line traces to runtime evidence. Belt-and-suspender
 
 Investigation fans out `how` + `why` as parallel subagents.
 
-**Reply:** what was broken, root cause, fix, how you verified. Quote the decisive failing line and the decisive passing line, trimmed to the assertion and the counts.
+**Reply:** what was broken, root cause, fix, how you verified. Quote the decisive failing and passing output, trimmed to the assertion and the counts.


### PR DESCRIPTION
Bug-fix replies were coming back at ~700 words. The required content was right; three lines in poteto-mode inflated it into a report with headers and pasted output blocks. This trims the waffle and the layout while keeping every required item.

- SKILL.md Non-negotiables now says a sentence per principle carries the principle and the choice it changed, and the justification stays in the work, not the reply. The old wording produced a justification paragraph per principle.
- The terse rule in Writing the reply now says every item the playbook names stays, rendered as prose, usually a sentence or two, longer when the content needs it, with no section headers and no item expanded into its own block. Calling each item a "section" licensed the header-per-item layout.
- The bug-fix playbook's Reply line now asks for the decisive failing and passing output, trimmed to the assertion and the counts, instead of verbatim repro output. The verbatim rule was the source of the pasted blocks.

Every playbook's Reply line still names the same required items. The budgets bind format and justification prose, not content.