### PR TITLE
Add Opus 5 to the model choices and update the default panel quad

### DIFF
--- a/plugins/pstack/skills/architect/SKILL.md
+++ b/plugins/pstack/skills/architect/SKILL.md
@@ -31,7 +31,7 @@ Skip Phase A only when the work is genuinely greenfield with no surrounding syst
 
 Run the **arena** skill with the design-sketch task and the Phase A grounding artifacts. Pass `references/runner-prompt.md` as each runner's prompt. Each candidate produces a design package shaped per `references/rationale-template.md`: the caller's usage written first, then the type sketch, function signatures, module map, and prose rationale derived from it.
 
-Use your configured architect runners (defaults `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-5`).
+Use your configured architect runners (defaults `claude-opus-5`, `claude-fable-5`, `claude-opus-4-6`, `claude-sonnet-5`).
 
 This is the **exhaust-the-design-space** principle skill made concrete. Whole-shape alternatives, not point fixes inside one shape.
 

--- a/plugins/pstack/skills/architect/SKILL.md
+++ b/plugins/pstack/skills/architect/SKILL.md
@@ -31,7 +31,7 @@ Skip Phase A only when the work is genuinely greenfield with no surrounding syst
 
 Run the **arena** skill with the design-sketch task and the Phase A grounding artifacts. Pass `references/runner-prompt.md` as each runner's prompt. Each candidate produces a design package shaped per `references/rationale-template.md`: the caller's usage written first, then the type sketch, function signatures, module map, and prose rationale derived from it.
 
-Use your configured architect runners (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-sonnet-4-6`).
+Use your configured architect runners (defaults `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-5`).
 
 This is the **exhaust-the-design-space** principle skill made concrete. Whole-shape alternatives, not point fixes inside one shape.
 

--- a/plugins/pstack/skills/arena/SKILL.md
+++ b/plugins/pstack/skills/arena/SKILL.md
@@ -26,7 +26,7 @@ The N candidates will receive the same prompt, so the prompt is the contract. Ge
 
 1. State the artifact each candidate is producing.
 2. Derive the rubric. State what success looks like for *this* task, then turn it into 3-6 concrete gradeable criteria. Concrete: `Adds a --dry-run flag that skips writes`. Vague: `code is correct`. The rubric is the picker's tool in Phase D; candidates only see the task.
-3. Pick the runners. Default runners are your configured arena list (defaults `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-5`). Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
+3. Pick the runners. Default runners are your configured arena list (defaults `claude-opus-5`, `claude-fable-5`, `claude-opus-4-6`, `claude-sonnet-5`). Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
 4. Assign output paths. Each candidate writes to its own location (a git worktree where possible, otherwise `/tmp/arena-<slug>/candidate-<n>/`). N candidates writing to the same path is shared mutable state and fails the the **separate-before-serializing-shared-state** principle skill test.
 
 ## Phase B: Fan out

--- a/plugins/pstack/skills/arena/SKILL.md
+++ b/plugins/pstack/skills/arena/SKILL.md
@@ -26,7 +26,7 @@ The N candidates will receive the same prompt, so the prompt is the contract. Ge
 
 1. State the artifact each candidate is producing.
 2. Derive the rubric. State what success looks like for *this* task, then turn it into 3-6 concrete gradeable criteria. Concrete: `Adds a --dry-run flag that skips writes`. Vague: `code is correct`. The rubric is the picker's tool in Phase D; candidates only see the task.
-3. Pick the runners. Default runners are your configured arena list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-sonnet-4-6`). Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
+3. Pick the runners. Default runners are your configured arena list (defaults `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-5`). Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
 4. Assign output paths. Each candidate writes to its own location (a git worktree where possible, otherwise `/tmp/arena-<slug>/candidate-<n>/`). N candidates writing to the same path is shared mutable state and fails the the **separate-before-serializing-shared-state** principle skill test.
 
 ## Phase B: Fan out

--- a/plugins/pstack/skills/how/SKILL.md
+++ b/plugins/pstack/skills/how/SKILL.md
@@ -111,7 +111,7 @@ Run the full explain flow above (Steps 1-4). You must understand the architectur
 
 ### Step 2. Spawn Critics
 
-After the explanation is complete, spawn one architectural critic per model in your configured how-critics list (defaults `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-5`), all in a single message.
+After the explanation is complete, spawn one architectural critic per model in your configured how-critics list (defaults `claude-opus-5`, `claude-fable-5`, `claude-opus-4-6`, `claude-sonnet-5`), all in a single message.
 
 For each critic:
 - `subagent_type`: `general-purpose`

--- a/plugins/pstack/skills/how/SKILL.md
+++ b/plugins/pstack/skills/how/SKILL.md
@@ -111,7 +111,7 @@ Run the full explain flow above (Steps 1-4). You must understand the architectur
 
 ### Step 2. Spawn Critics
 
-After the explanation is complete, spawn one architectural critic per model in your configured how-critics list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-sonnet-4-6`), all in a single message.
+After the explanation is complete, spawn one architectural critic per model in your configured how-critics list (defaults `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-5`), all in a single message.
 
 For each critic:
 - `subagent_type`: `general-purpose`

--- a/plugins/pstack/skills/interrogate/SKILL.md
+++ b/plugins/pstack/skills/interrogate/SKILL.md
@@ -34,7 +34,7 @@ Write one clear paragraph. Reviewers challenge whether the work achieves the int
 
 ## Step 3, Spawn Reviewers
 
-Launch one reviewer per model in your configured interrogate list (defaults `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-5`), all in a single message.
+Launch one reviewer per model in your configured interrogate list (defaults `claude-opus-5`, `claude-fable-5`, `claude-opus-4-6`, `claude-sonnet-5`), all in a single message.
 
 For each reviewer:
 - `subagent_type`: `general-purpose`

--- a/plugins/pstack/skills/interrogate/SKILL.md
+++ b/plugins/pstack/skills/interrogate/SKILL.md
@@ -34,7 +34,7 @@ Write one clear paragraph. Reviewers challenge whether the work achieves the int
 
 ## Step 3, Spawn Reviewers
 
-Launch one reviewer per model in your configured interrogate list (defaults `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-sonnet-4-6`), all in a single message.
+Launch one reviewer per model in your configured interrogate list (defaults `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-6`, `claude-sonnet-5`), all in a single message.
 
 For each reviewer:
 - `subagent_type`: `general-purpose`

--- a/plugins/pstack/skills/setup-pstack/SKILL.md
+++ b/plugins/pstack/skills/setup-pstack/SKILL.md
@@ -21,7 +21,7 @@ so the file is loaded as context for every session.
 
 ### 1. Detect available models
 
-Enumerate the model slugs you can pass to an `Agent` subagent in this session — that is the dependable source. Claude family currently available: Opus 5 (`claude-opus-5`), Opus 4.8 (`claude-opus-4-8`), Opus 4.6 (`claude-opus-4-6`), Fable 5 (`claude-fable-5`), Sonnet 5 (`claude-sonnet-5`), Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5`). The default panels run three opus generations (`5`, `4-8`, `4-6`) and Sonnet 5 (`claude-sonnet-5`) for cross-generation, cross-tier diversity. Ask the user to confirm or paste any additional slugs they want available. Never write a slug you have not confirmed is available.
+Enumerate the model slugs you can pass to an `Agent` subagent in this session — that is the dependable source. Claude family currently available: Opus 5 (`claude-opus-5`), Opus 4.8 (`claude-opus-4-8`), Opus 4.6 (`claude-opus-4-6`), Fable 5 (`claude-fable-5`), Sonnet 5 (`claude-sonnet-5`), Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5`). The default panels run Opus 5 (`claude-opus-5`), Fable 5 (`claude-fable-5`), Opus 4.6 (`claude-opus-4-6`), and Sonnet 5 (`claude-sonnet-5`) for cross-family, cross-tier diversity. Opus 4.8 stays out of the panels because it is already the single-role default across the skills. Ask the user to confirm or paste any additional slugs they want available. Never write a slug you have not confirmed is available.
 
 ### 2. Load current state
 
@@ -51,15 +51,15 @@ hillclimb: claude-opus-4-8
 judgment and prose: claude-opus-4-8
 how explorer: claude-opus-4-8
 how explainer: claude-opus-4-8
-how critics: claude-opus-5, claude-opus-4-8, claude-opus-4-6, claude-sonnet-5
+how critics: claude-opus-5, claude-fable-5, claude-opus-4-6, claude-sonnet-5
 why investigators: claude-opus-4-8
 why synthesizer: claude-opus-4-8
 reflect tooling: claude-opus-4-8
 reflect judgment, divergent, synthesizer: claude-opus-4-8
-arena runners: claude-opus-5, claude-opus-4-8, claude-opus-4-6, claude-sonnet-5
-arena cross-judge pool: claude-opus-5, claude-opus-4-8, claude-sonnet-5
-architect runners: claude-opus-5, claude-opus-4-8, claude-opus-4-6, claude-sonnet-5
-interrogate reviewers: claude-opus-5, claude-opus-4-8, claude-opus-4-6, claude-sonnet-5
+arena runners: claude-opus-5, claude-fable-5, claude-opus-4-6, claude-sonnet-5
+arena cross-judge pool: claude-opus-5, claude-fable-5, claude-sonnet-5
+architect runners: claude-opus-5, claude-fable-5, claude-opus-4-6, claude-sonnet-5
+interrogate reviewers: claude-opus-5, claude-fable-5, claude-opus-4-6, claude-sonnet-5
 ```
 
 ### 6. Wire it in

--- a/plugins/pstack/skills/setup-pstack/SKILL.md
+++ b/plugins/pstack/skills/setup-pstack/SKILL.md
@@ -21,7 +21,7 @@ so the file is loaded as context for every session.
 
 ### 1. Detect available models
 
-Enumerate the model slugs you can pass to an `Agent` subagent in this session — that is the dependable source. Claude family currently available: Opus 4.8 (`claude-opus-4-8`), Fable 5 (`claude-fable-5`), Sonnet 5 (`claude-sonnet-5`), Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5`). The default panels run Opus 4.8 (`claude-opus-4-8`), Fable 5 (`claude-fable-5`), and both sonnet generations (`5`, `4-6`) for cross-family, cross-tier diversity. Ask the user to confirm or paste any additional slugs they want available. Never write a slug you have not confirmed is available.
+Enumerate the model slugs you can pass to an `Agent` subagent in this session — that is the dependable source. Claude family currently available: Opus 5 (`claude-opus-5`), Opus 4.8 (`claude-opus-4-8`), Opus 4.6 (`claude-opus-4-6`), Fable 5 (`claude-fable-5`), Sonnet 5 (`claude-sonnet-5`), Sonnet 4.6 (`claude-sonnet-4-6`), Haiku 4.5 (`claude-haiku-4-5`). The default panels run three opus generations (`5`, `4-8`, `4-6`) and Sonnet 5 (`claude-sonnet-5`) for cross-generation, cross-tier diversity. Ask the user to confirm or paste any additional slugs they want available. Never write a slug you have not confirmed is available.
 
 ### 2. Load current state
 
@@ -51,15 +51,15 @@ hillclimb: claude-opus-4-8
 judgment and prose: claude-opus-4-8
 how explorer: claude-opus-4-8
 how explainer: claude-opus-4-8
-how critics: claude-opus-4-8, claude-sonnet-5, claude-fable-5, claude-sonnet-4-6
+how critics: claude-opus-5, claude-opus-4-8, claude-opus-4-6, claude-sonnet-5
 why investigators: claude-opus-4-8
 why synthesizer: claude-opus-4-8
 reflect tooling: claude-opus-4-8
 reflect judgment, divergent, synthesizer: claude-opus-4-8
-arena runners: claude-opus-4-8, claude-sonnet-5, claude-fable-5, claude-sonnet-4-6
-arena cross-judge pool: claude-opus-4-8, claude-sonnet-5, claude-fable-5
-architect runners: claude-opus-4-8, claude-sonnet-5, claude-fable-5, claude-sonnet-4-6
-interrogate reviewers: claude-opus-4-8, claude-sonnet-5, claude-fable-5, claude-sonnet-4-6
+arena runners: claude-opus-5, claude-opus-4-8, claude-opus-4-6, claude-sonnet-5
+arena cross-judge pool: claude-opus-5, claude-opus-4-8, claude-sonnet-5
+architect runners: claude-opus-5, claude-opus-4-8, claude-opus-4-6, claude-sonnet-5
+interrogate reviewers: claude-opus-5, claude-opus-4-8, claude-opus-4-6, claude-sonnet-5
 ```
 
 ### 6. Wire it in


### PR DESCRIPTION
- setup-pstack's available-model enumeration adds Opus 5 (`claude-opus-5`) and Opus 4.6 (`claude-opus-4-6`). Fable 5, Sonnet 4.6, and Haiku 4.5 stay listed as choices.
- The default four-model panel becomes `claude-opus-5`, `claude-fable-5`, `claude-opus-4-6`, `claude-sonnet-5`, replacing Opus 4.8 and Sonnet 4.6. Opus 4.8 stays out of the panels because it is already the single-role default across the skills. Updated in setup-pstack's override sheet and in the inline defaults in arena, architect, interrogate, and how.
- The arena cross-judge pool becomes `claude-opus-5`, `claude-fable-5`, `claude-sonnet-5`.

Single-role defaults (`claude-opus-4-8` for feature, bug-fix, and the rest) and poteto-mode's strongest-judgment reference to `claude-fable-5` are unchanged.