### PR TITLE
docs: make skills installable by Prime Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# pstack for Claude Code and Codex
+# pstack for Claude Code, Codex, and Prime Agent
 
-Claude Code port of [poteto](https://x.com/poteto)'s [pstack](https://github.com/cursor/plugins/tree/main/pstack) plugin (skill tree synced against upstream `e46364b`, pstack v0.9.2; upstream reviewed through `0452e08`, v0.10.0 — see [What's deliberately not ported](#whats-deliberately-not-ported)). The same `skills/` tree also ships as a Codex plugin; see [Running on Codex](#running-on-codex). Original by Lauren Tan; ships MIT. Imports seven skills from [cursor-team-kit](https://github.com/cursor/plugins/tree/main/cursor-team-kit) (also MIT): `deslop`, `thermo-nuclear-code-quality-review`, `make-pr-easy-to-review`, `fix-ci`, `fix-merge-conflicts`, `get-pr-comments`, `what-did-i-get-done`.
+Claude Code port of [poteto](https://x.com/poteto)'s [pstack](https://github.com/cursor/plugins/tree/main/pstack) plugin (skill tree synced against upstream `e46364b`, pstack v0.9.2; upstream reviewed through `0452e08`, v0.10.0 — see [What's deliberately not ported](#whats-deliberately-not-ported)). The same `skills/` tree also ships as a Codex plugin (see [Running on Codex](#running-on-codex)) and is discovered as-is by [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) (see [Prime Agent](#prime-agent)). Original by Lauren Tan; ships MIT. Imports seven skills from [cursor-team-kit](https://github.com/cursor/plugins/tree/main/cursor-team-kit) (also MIT): `deslop`, `thermo-nuclear-code-quality-review`, `make-pr-easy-to-review`, `fix-ci`, `fix-merge-conflicts`, `get-pr-comments`, `what-did-i-get-done`.
 
 > if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.
 
@@ -45,6 +45,20 @@ for c in plugins/pstack/commands/*.md; do ln -s "$PWD/$c" ~/.codex/prompts/"$(ba
 
 Each command invokes its skill, so `/tdd` runs the `tdd` skill. Installing the full plugin through the Codex marketplace (the root `.agents/plugins/marketplace.json`) carries skills and commands together; the two symlink steps above are the verified local path. Teardown is `rm ~/.agents/skills/<name>` and `rm ~/.codex/prompts/<name>.md`.
 
+### Prime Agent
+
+[Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) discovers skills from `~/.agents/skills/` and from `.agents/skills/` in the working tree up to the git root ([docs](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/docs/skills.md)). That is the same `~/.agents/skills/` directory the Codex install symlinks into, so the [Codex skill-link step](#codex) doubles as the Prime install — if you have already run it, Prime picks the skills up with no extra work:
+
+```shell
+git clone https://github.com/michael-denyer/pstack-claude
+cd pstack-claude
+for s in plugins/pstack/skills/*/; do ln -s "$PWD/$s" ~/.agents/skills/"$(basename "$s")"; done
+```
+
+pstack's `SKILL.md` frontmatter is a subset of what Prime reads: it requires `name` (lowercase, matching the parent directory — every pstack skill already conforms) and `description`, honours `disable-model-invocation`, and ignores unknown keys such as pstack's `user-invocable`. `curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh` installs Prime itself; `--no-skills` disables discovery, and explicit `--skill <path>` still loads. Prime is model-agnostic, so running these skills against **ChatGPT / OpenAI models is a Prime backend setting, not a plugin change** — keep the multi-model panels in `arena`, `interrogate`, `architect`, and `how` genuinely diverse across whatever models you configure (see the OpenAI panel note under [Running on Codex](#running-on-codex)).
+
+Unverified relative to Codex: the Codex path above is confirmed on a live session; the Prime path is derived from Prime's documented discovery paths and frontmatter schema, not yet run on a live Prime session. Prime has no plugin-hook runtime, so the Claude Code auto-fire hook does not apply — enter `pstack:poteto-mode` by name or add a standing routing instruction to your Prime config. Teardown is `rm ~/.agents/skills/<name>`.
+
 ## Layout
 
 ```text
@@ -54,7 +68,7 @@ Each command invokes its skill, so `/tdd` runs the `tdd` skill. Installing the f
 ├── plugins/pstack/                   # the plugin itself
 │   ├── .claude-plugin/plugin.json    # Claude Code manifest
 │   ├── .codex-plugin/plugin.json     # Codex manifest (skills: ./skills/)
-│   ├── skills/                       # 48 skills (shared by both runtimes)
+│   ├── skills/                       # 48 skills (shared by all three runtimes)
 │   │   └── poteto-mode/references/codex-tools.md  # Claude→Codex tool/model/skill map
 │   ├── commands/                     # 27 slash command stubs (Codex-compatible; link into ~/.codex/prompts)
 │   ├── hooks/                        # SessionStart auto-fire: injects the poteto-mode mandate (Claude Code only)


### PR DESCRIPTION
## What

Documents installing the pstack skills under Prime Agent (`PrimeIntellect-ai/prime-agent`), and names it as a third supported runtime alongside Claude Code and Codex.

- Add a **Prime Agent** install section. Prime discovers skills from `~/.agents/skills/` and project `.agents/skills/` up to the git root, which is the exact directory the Codex skill-link step already targets, so that one symlink command doubles as the Prime install.
- Note that pstack's `SKILL.md` frontmatter (`name`, `description`, `disable-model-invocation`) is a subset of Prime's schema, and Prime ignores unknown keys such as `user-invocable`.
- State that running against ChatGPT/OpenAI models is a Prime backend setting, not a plugin change, and to keep the multi-model panels diverse across whatever models are configured.
- Update the title and the layout comment to name all three runtimes.

## No manifest or version change

Prime uses filesystem discovery; it needs no marketplace manifest, so nothing under `.claude-plugin/`, `.agents/plugins/`, or `.codex-plugin/` changes. Consistent with the last three PRs, which added content on top of 0.9.10 without a version bump.

## Verification

- Skill count still 48; every skill's `name` matches its parent directory, which is what Prime requires.
- Frontmatter compatibility confirmed against Prime's [skills docs](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/docs/skills.md): unknown keys are ignored.
- Not run on a live Prime session. The README marks the Prime path as documentation-derived rather than live-verified, unlike the Codex path.