### PR TITLE
Post-review fixes: bun preflight guard + no-comments Platform note

### DIFF
--- a/plugins/pstack/skills/no-comments/SKILL.md
+++ b/plugins/pstack/skills/no-comments/SKILL.md
@@ -9,7 +9,7 @@ Spawn comment-sicko. Act on accepted findings.
 
 Authoring agents defend comments. Defer to comment-sicko's fresh perspective.
 
-**Platform note.** On Codex or another non-Claude runtime, there is no `comment-sicko` subagent type; dispatch a `spawn_agent` told to read `agents/comment-sicko.md` first. Resolve the tool names via [`codex-tools.md`](../poteto-mode/references/codex-tools.md).
+**Platform note.** On Codex or another non-Claude runtime, the `comment-sicko` subagent and the Claude tool names below are Claude defaults. Resolve them via [`codex-tools.md`](../poteto-mode/references/codex-tools.md).
 
 ## Scope
 

--- a/plugins/pstack/skills/poteto-mode/scripts/bootstrap.ts
+++ b/plugins/pstack/skills/poteto-mode/scripts/bootstrap.ts
@@ -2,6 +2,15 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+// This tooling is bun-only (import.meta.dir, Bun.spawnSync, bun.lock). Fail with a
+// clear message instead of an opaque `import.meta.dir is undefined` crash under node.
+if (typeof Bun === "undefined") {
+  console.error(
+    "pstack poteto-mode tooling requires bun (https://bun.sh). Install bun, then re-run."
+  );
+  process.exit(1);
+}
+
 const scriptsDirectory = import.meta.dir;
 const nodeModulesDirectory = join(scriptsDirectory, "node_modules");
 const commanderPackagePath = join(


### PR DESCRIPTION
Two clearly-correct fixes surfaced by the post-merge review of the v0.14.2 sync (#23). The other review findings were either by-design (autopilot autonomy, the worktree-cleanup force-remove step) or correct as-is on inspection (automate-me's `disable-model-invocation` for generated mode skills; the comment-sicko persona heading), so they are deliberately not touched here.

## Changes
- **`bootstrap.ts` — bun preflight guard.** The vendored poteto-mode tooling is bun-only (`import.meta.dir`, `Bun.spawnSync`, `bun.lock`). Under node it crashed with an opaque `import.meta.dir is undefined` error before any dependency check. Now it checks for a missing `Bun` global and exits with `pstack poteto-mode tooling requires bun (https://bun.sh)`. Verified: prints the message and exits 1 under node; no effect under bun.
- **`no-comments/SKILL.md` — Platform note.** It inlined the Cursor `spawn_agent` mechanics, duplicating `references/codex-tools.md:38`, which already owns that instruction. Reduced to the one-line pointer every other skill's Platform note uses (matches `swarm`).

## Verification
- `bun test orch watch-pr` → **52 pass / 0 fail** (after `bun install --frozen-lockfile`), unchanged by the guard.
- `tests/skill-collision-repro.sh` exits 0 (flag/collision/quad/version invariants).
- `node_modules` stays gitignored; 2-file diff, no drive-by changes.

## Not fixed here (flagged for your decision, not defects)
- `autopilot-full.md` merges to trunk gated only on a swarm verdict; `worktree-cleanup.md`'s force-remove step is gated on prior classification. Both by-design autonomy — a product call on whether to keep, gate harder, or drop.
