### PR TITLE
Pin the layered report format for thermo-nuclear reviews

### DIFF
--- a/plugins/pstack/skills/thermo-nuclear-code-quality-review/SKILL.md
+++ b/plugins/pstack/skills/thermo-nuclear-code-quality-review/SKILL.md
@@ -165,6 +165,16 @@ Prioritize findings in this order:
 Do not flood the review with low-value nits if there are larger structural issues.
 Prefer a smaller number of high-conviction comments over a long list of cosmetic notes.
 
+## Report Format
+
+The deliverable is layered, never a single monolithic file:
+
+- Write the review to its own directory (for example `/tmp/<project>-thermo/`): one summary report plus one detailed report per subsystem or reviewer (`01_<subsystem>.md`, `02_<subsystem>.md`, ...).
+- Keep the summary readable in one sitting, around 200 lines: the verdict, each finding as a short narrative paragraph, a proposed remediation sequence, and a pointer to the detail file that carries the finding's full evidence.
+- Detail files carry the depth: measurements, the commands that produced them, verification status, and worked code-judo proposals.
+- Write findings as prose paragraphs. Name the file and the evidence, then explain the problem and the remedy in sentences. Do not compress findings into fragment lines, tag soup, or inline command dumps in the summary.
+- When the review fans out parallel reviewers via the **swarm** skill, this section overrides swarm's aggregation rules: per-reviewer reports are the deliverable's detail files, not raw dumps to discard. Consolidate judgment into the summary; keep the details on disk and link to them.
+
 ## Approval Bar
 
 Do not approve merely because behavior seems correct.


### PR DESCRIPTION
## What

Adds a Report Format section to the thermo-nuclear skill. It pins the deliverable the skill produced before the v0.14.2 sync: a summary of about 200 lines in narrative prose, plus one detail file per subsystem reviewer, written to a dedicated directory. The section states that it overrides the swarm skill's aggregation rules for this review, so per-reviewer reports become the deliverable's detail files instead of raw dumps to discard.

## Why

The v0.14.2 sync added the swarm skill, and poteto-mode now routes parallel fan-out through it. Swarm's phase C and D rules ("do not paste raw worker dumps", "return one consolidated in-chat report") flattened the first thermo review run after the sync (wpredict, 2026-08-26) into one dense file with inline command dumps and tag soup. The review before the sync (lab_disco, 2026-08-21) produced a 196-line summary plus 10 per-subsystem reports, which read far better. The skill never specified a report shape, so swarm's rules won by default. Now it does.

## Open risk

The section prescribes a /tmp directory layout by example. A session that must not write outside the repo will need to pick another location; the section leaves the path open for that reason.