### PR TITLE
Release 0.9.12: pin the thermo-nuclear report format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pstack",
       "source": "./plugins/pstack",
       "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "author": {
         "name": "Lauren Tan (original)"
       },

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This port applies the Cursor → Claude Code substitutions in skill bodies. Earlier drafts left them flagged; this revision resolves them. A later pass added a Codex build that shares the same skills; see [Codex port](#codex-port) below.
 
+## 0.9.12 — pin the thermo-nuclear report format
+
+The 0.9.11 swarm routing flattened thermo-nuclear reviews into one consolidated report, dropping the summary-plus-per-subsystem-file layout earlier reviews produced. `thermo-nuclear-code-quality-review` now carries a Report Format section that pins the layered deliverable (a ~200-line narrative summary plus one detail file per subsystem reviewer) and overrides swarm's aggregation rules for this review (#28).
+
 ## 0.9.11 — sync to upstream v0.14.2
 
 Catches the port up with upstream `cursor/plugins/pstack` from `3fe2823` (v0.11.3) to `4612556` (v0.14.2). Skills 48 → 52, commands 27 → 31, subagents 1 → 2, plus a vendored `scripts/` tree under `poteto-mode/`.

--- a/plugins/pstack/.claude-plugin/plugin.json
+++ b/plugins/pstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pstack",
   "displayName": "pstack (Claude Code port)",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Ported from cursor/plugins/pstack to Claude Code.",
   "author": {
     "name": "Lauren Tan"

--- a/plugins/pstack/.codex-plugin/plugin.json
+++ b/plugins/pstack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pstack",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Codex port of the Claude Code plugin; skills are shared, tool names resolve via skills/poteto-mode/references/codex-tools.md.",
   "author": {
     "name": "Lauren Tan"


### PR DESCRIPTION
Bumps the plugin version to 0.9.12 across the three manifests so installed copies pick up #28 on the next marketplace update. Adds the CHANGES.md entry. Plugin auto-update installs by version number, so #28 was inert on machines still caching 0.9.11.