### PR TITLE
Add CI, security scanning, and dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Pinned action SHAs go stale silently; this is what keeps them current.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+
+  - package-ecosystem: npm
+    directory: /plugins/pstack/skills/poteto-mode/scripts
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  invariants:
+    name: Plugin invariants
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # The behavioral leg needs the claude CLI and API access, so it is skipped
+      # here; SKIP_BEHAVIORAL keeps the static invariants running.
+      - name: Run static invariants
+        env:
+          SKIP_BEHAVIORAL: "1"
+        run: bash tests/skill-collision-repro.sh
+
+  scripts:
+    name: Vendored bun tooling
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/pstack/skills/poteto-mode/scripts
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          # Match the version the invariants were last verified against locally.
+          bun-version: "1.3.14"
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Test
+        run: bun test orch watch-pr
+
+  shellcheck:
+    name: Shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run shellcheck
+        run: |
+          shellcheck --version
+          find . -path ./.git -prune -o -name '*.sh' -print0 \
+            | xargs -0 shellcheck --severity=warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ jobs:
     name: Plugin invariants
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials: false on every checkout — nothing here needs git
+      # auth after the clone, and a stored token can leak via artifacts.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # The behavioral leg needs the claude CLI and API access, so it is skipped
       # here; SKIP_BEHAVIORAL keeps the static invariants running.
       - name: Run static invariants
@@ -33,6 +37,8 @@ jobs:
         working-directory: plugins/pstack/skills/poteto-mode/scripts
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           # Match the version the invariants were last verified against locally.
@@ -49,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Run shellcheck
         run: |
           shellcheck --version

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,11 @@ jobs:
     name: OSV vulnerability scan
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials: false on every checkout — nothing here needs git
+      # auth after the clone, and a stored token can leak via artifacts.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # Pinned to the image rather than google/osv-scanner-action, whose own
       # README warns its behavior can change in a patch release.
       #
@@ -38,12 +42,38 @@ jobs:
             exit 1
           fi
 
+  zizmor:
+    name: Workflow static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # Audits the workflows themselves: template injection, over-broad
+      # permissions, unpinned actions, credential persistence.
+      #
+      # advanced-security defaults to true and needs GitHub Advanced Security,
+      # which this repo does not have; annotations put findings on the diff
+      # instead. version defaults to "latest" — pinned so a zizmor release
+      # cannot change what this gate means.
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          version: "1.29.0"
+          advanced-security: false
+          annotations: true
+          persona: pedantic
+          min-severity: low
+
   actions-pinned:
     name: Actions pinned to SHAs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # A mutable tag (@v7) can be force-pushed to inject code into our runners.
+        with:
+          persist-credentials: false
+      # zizmor's unpinned-uses audit covers this too, but only for files it
+      # parses as workflows. This is a cheap belt-and-braces grep that also
+      # catches a malformed workflow zizmor skips.
       - name: Reject unpinned action references
         run: |
           unpinned="$(grep -rnE '^\s*(- )?uses:' .github/workflows \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,56 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly, so a CVE published after merge still surfaces.
+    - cron: "17 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  osv-scan:
+    name: OSV vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Pinned to the image rather than google/osv-scanner-action, whose own
+      # README warns its behavior can change in a patch release.
+      #
+      # --include-git-root is required: the scanner skips the git root by
+      # default, and the only lockfile lives inside this repo. Without it the
+      # scan finds nothing and passes, which reads exactly like a clean result.
+      - name: Scan lockfiles
+        run: |
+          docker run --rm -v "$PWD:/src" \
+            ghcr.io/google/osv-scanner:v2.5.1 \
+            scan source --recursive --include-git-root /src \
+            | tee osv-output.txt
+          if grep -q 'No package sources found' osv-output.txt; then
+            echo "FAIL: osv-scanner found no lockfiles to scan; a silent pass is not a clean scan"
+            exit 1
+          fi
+
+  actions-pinned:
+    name: Actions pinned to SHAs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # A mutable tag (@v7) can be force-pushed to inject code into our runners.
+      - name: Reject unpinned action references
+        run: |
+          unpinned="$(grep -rnE '^\s*(- )?uses:' .github/workflows \
+            | grep -vE 'uses:\s*\S+@[0-9a-f]{40}' || true)"
+          if [ -n "$unpinned" ]; then
+            echo "FAIL: actions must be pinned to a full commit SHA:"
+            echo "$unpinned"
+            exit 1
+          fi
+          echo "ok: every action reference is pinned to a 40-character SHA"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+Thanks for helping out. This repo is a **port**, not an original work: the `skills/` tree tracks [upstream pstack](https://github.com/cursor/plugins/tree/main/pstack) and gets synced forward periodically. That one fact shapes most of what follows.
+
+## The sync boundary
+
+Upstream owns skill content. This port owns the Cursor-to-Claude-Code translation.
+
+Before changing a `SKILL.md`, work out which side your change lives on:
+
+- **Fixing the port.** A Cursor primitive that resolves wrong on Claude Code, a broken cross-reference, a stale model slug. Belongs here. Open a PR.
+- **Changing what a skill does.** New steps, a different workflow, reworded guidance. Usually belongs upstream. Land it there and it arrives here on the next sync. If you land it only here, the next sync conflicts with it and someone has to re-litigate the change under time pressure.
+
+Local-only changes are fine when they're genuinely port-specific. Say so in the PR description, so the next sync knows it is deliberate and not drift.
+
+Every substitution is recorded per-skill in [CHANGES.md](CHANGES.md). If you add one, record it there in the same PR.
+
+## Before you open a PR
+
+Run the invariant script:
+
+```shell
+bash tests/skill-collision-repro.sh
+```
+
+It checks plugin layout, frontmatter flags, version parity across the three manifests, and that the default model quad is identical everywhere it appears. The last check is behavioral: it needs the `claude` CLI and API access and makes one haiku call. CI runs everything except that leg via `SKIP_BEHAVIORAL=1`, so run it unflagged at least once before a release.
+
+If you touched `skills/poteto-mode/scripts/`:
+
+```shell
+cd plugins/pstack/skills/poteto-mode/scripts
+bun install --frozen-lockfile
+bun run typecheck
+bun test orch watch-pr
+```
+
+If you touched a workflow, audit it before pushing:
+
+```shell
+uvx zizmor@1.29.0 --persona pedantic --min-severity low .github/workflows/
+```
+
+## Things that will fail CI
+
+- **A `plugins/pstack/commands/` directory.** Claude Code renders commands and user-invocable skills in the same slash menu, so a trampoline paired with its skill duplicates every `/pstack:<name>` row ([#22](https://github.com/michael-denyer/pstack-claude/issues/22)). Codex stubs live in `plugins/pstack/.codex-plugin/prompts/`. An upstream sync will try to reintroduce `commands/`; move any new stubs across.
+- **`disable-model-invocation` in a skill's frontmatter.** On a skill it makes the Skill tool refuse the invocation outright, which breaks the SessionStart mandate. The `principle-*` leaves use `user-invocable: false` instead.
+- **A version bump in only some manifests.** The version string is duplicated in `plugins/pstack/.claude-plugin/plugin.json`, `plugins/pstack/.codex-plugin/plugin.json`, and `.claude-plugin/marketplace.json`. All three move together.
+- **An action pinned to a tag.** Use the full 40-character commit SHA with a version comment. A mutable tag can be force-pushed into our runners.
+
+## Releasing
+
+Plugin auto-update installs **by version number**, not by tracking `main`. A skill fix merged without a version bump is inert on every installed copy, because the updater sees the same version it already has and does nothing.
+
+So: any PR that changes skill behavior either bumps the version itself or is followed by a release PR that does. Bump all three manifests, add a `CHANGES.md` entry describing what changed and why, and run the full invariant script (including the behavioral leg) before merging.
+
+## Commit and PR style
+
+- Explain what changed and why. The diff already shows how.
+- One concern per PR. A behavior fix and a refactor in the same diff are two separate reviews, and reviewing them together means doing neither properly.
+- Claim only what you verified, and name the check. "52/52 bun tests pass" beats "tests pass"; "did not run the behavioral leg" beats silence.
+
+## Reporting bugs
+
+Include the pstack version, the Claude Code (or Codex) version, and the reproduction steps. [#22](https://github.com/michael-denyer/pstack-claude/issues/22) is the model to copy: it named versions, gave numbered steps, and included the experiment that isolated the cause.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Unverified relative to Codex: the Codex path above is confirmed on a live sessio
 ├── LICENSE                           # pstack upstream MIT
 ├── LICENSE-cursor-team-kit           # cursor-team-kit upstream MIT
 ├── LICENSE-superpowers               # superpowers upstream MIT (hook runner)
+├── CONTRIBUTING.md                   # sync boundary, local checks, release rules
 ├── NOTICE.md                         # attribution table
 ├── CHANGES.md                        # per-skill substitution audit
 └── README.md                         # this file
@@ -108,6 +109,8 @@ Two workflows run on every pull request and push to `main`.
 `security.yml` runs `osv-scanner` against the lockfiles and fails the build if no lockfile was found, because an empty scan reads exactly like a clean one. It also rejects any action reference not pinned to a full 40-character commit SHA. It runs weekly on top of the per-PR trigger, so a CVE published after a merge still surfaces. Dependabot keeps the pinned SHAs and the bun dependencies current.
 
 Before a release, run the full `tests/skill-collision-repro.sh` locally (without `SKIP_BEHAVIORAL`) to exercise the behavioral leg CI cannot.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the sync boundary, the local checks to run, and the release rules.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Unverified relative to Codex: the Codex path above is confirmed on a live sessio
 
 ```text
 .
+├── .github/workflows/               # CI: invariants, bun tooling, shellcheck, OSV scan
 ├── .claude-plugin/marketplace.json   # Claude Code marketplace manifest (repo root)
 ├── .agents/plugins/marketplace.json  # Codex marketplace manifest (repo root)
 ├── plugins/pstack/                   # the plugin itself
@@ -97,6 +98,16 @@ The Codex build shares one `skills/` tree with the Claude Code build. Nothing is
 - **Models.** The `claude-*` slugs in skills are Claude defaults. On Codex substitute your configured Codex models, keeping multi-model panels genuinely diverse. `/setup-pstack` writes `~/.codex/pstack-models.md` (referenced from `~/.codex/AGENTS.md`) with Codex slugs instead of `~/.claude/pstack-models.md`.
 
 Verified on a live Codex session installed via the symlinks: the user-facing skills are discovered and namespaced under `pstack` (`pstack:poteto-mode`, `pstack:interrogate`, and so on). The `principle-*` leaf skills carry `user-invocable: false` and no command, so Codex does not surface them in the picker, the same as Claude Code. They stay installed for `poteto-mode` to read by path. The deeper behaviors (mapping resolution mid-task, `spawn_agent` fan-out) follow the proven `superpowers` pattern and are worth confirming in your own session.
+
+## CI
+
+Two workflows run on every pull request and push to `main`.
+
+`ci.yml` runs three jobs: the static plugin invariants (`tests/skill-collision-repro.sh` under `SKIP_BEHAVIORAL=1`, since the behavioral leg needs the `claude` CLI and API access), the vendored bun tooling (`bun install --frozen-lockfile`, `bun run typecheck`, `bun test orch watch-pr`), and `shellcheck` over every `.sh` file.
+
+`security.yml` runs `osv-scanner` against the lockfiles and fails the build if no lockfile was found, because an empty scan reads exactly like a clean one. It also rejects any action reference not pinned to a full 40-character commit SHA. It runs weekly on top of the per-PR trigger, so a CVE published after a merge still surfaces. Dependabot keeps the pinned SHAs and the bun dependencies current.
+
+Before a release, run the full `tests/skill-collision-repro.sh` locally (without `SKIP_BEHAVIORAL`) to exercise the behavioral leg CI cannot.
 
 ## Dependencies
 

--- a/tests/skill-collision-repro.sh
+++ b/tests/skill-collision-repro.sh
@@ -139,6 +139,14 @@ fi
 # via the skill alone. This is the assumption that lets pstack live without
 # trampolines; if it fails, upstream changed slash resolution — re-read #22 and
 # CHANGES 0.9.13 before reintroducing commands/. Last verified on 2.1.245.
+#
+# Needs the claude CLI and API access, so CI sets SKIP_BEHAVIORAL=1 and runs the
+# static invariants only. Run it locally before a release.
+if [ -n "${SKIP_BEHAVIORAL:-}" ]; then
+  note "skip: behavioral leg (SKIP_BEHAVIORAL set); static invariants only"
+  exit "$fail"
+fi
+
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 mkdir -p "$scratch/.claude-plugin" "$scratch/skills/foo"


### PR DESCRIPTION
## What

The repo had no workflows. `tests/skill-collision-repro.sh` and the vendored bun tooling only ran when someone remembered to run them.

**`ci.yml`** — three jobs on every PR and push to `main`:

- Static plugin invariants, via a new `SKIP_BEHAVIORAL=1` flag. The behavioral leg needs the `claude` CLI and API access, so CI runs the six static checks and skips it.
- Vendored bun tooling: `bun install --frozen-lockfile`, `bun run typecheck`, `bun test orch watch-pr`.
- `shellcheck --severity=warning` over every `.sh` file.

**`security.yml`** — OSV scanning plus a pinning guard, also weekly so a CVE published after merge still surfaces.

**`dependabot.yml`** — weekly updates for the pinned action SHAs and the bun dependencies.

## Two things worth reviewing

**The OSV scan pins the container image, not the action.** `google/osv-scanner-action`'s own README warns its behavior can change in a patch release. Pinning `ghcr.io/google/osv-scanner:v2.5.1` directly avoids that.

**`--include-git-root` is load-bearing.** The scanner skips the git root by default, so without it the scan walks one directory, finds no lockfile, and exits 0 — indistinguishable from a clean result. I hit exactly this while verifying. The step now fails on `No package sources found`, so a silent pass cannot masquerade as a green scan.

## Verification

All run locally against this branch:

- Invariants: 7/7 pass (6 static under `SKIP_BEHAVIORAL=1`, plus the behavioral leg unflagged).
- `shellcheck`: clean.
- `bun run typecheck`: clean. `bun test orch watch-pr`: 52 pass, 0 fail.
- `osv-scanner` against the real `bun.lock`: 25 packages, no known vulnerabilities.

The pinned bun version (1.3.14) matches the local version those results came from.

## Risk

Docker on macOS does not share `/tmp` by default, so running the OSV step by hand from a `/tmp` worktree scans an empty mount. That is a local sandbox quirk, not a CI one — GitHub's runner checks out into the workspace — but it is why the "no package sources" guard exists.