### PR TITLE
Add a 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,16 @@
 version: 2
 updates:
   # Pinned action SHAs go stale silently; this is what keeps them current.
+  #
+  # cooldown holds each update for 7 days after release. Without it Dependabot
+  # opens a PR the moment a version ships, which is exactly the window a
+  # compromised release is still unreported.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ci
 
@@ -12,5 +18,7 @@ updates:
     directory: /plugins/pstack/skills/poteto-mode/scripts
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: deps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,10 @@ bun test orch watch-pr
 If you touched a workflow, audit it before pushing:
 
 ```shell
-uvx zizmor@1.29.0 --persona pedantic --min-severity low .github/workflows/
+uvx zizmor@1.29.0 --persona pedantic --min-severity low --collect all -- .
 ```
+
+`--collect all` matches what CI scans. Pointing zizmor at `.github/workflows/` alone skips `dependabot.yml`, so the local run comes back clean on findings CI will fail on.
 
 ## Things that will fail CI
 


### PR DESCRIPTION
Fixes the `Workflow static analysis` job, the only failure in the first CI run on `main` (run [33021052198](https://github.com/michael-denyer/pstack-claude/actions/runs/33021052198)). The other five jobs passed.

## The finding

zizmor flagged both Dependabot update groups:

```
dependabot.yml:4: insufficient cooldown in Dependabot updates
dependabot.yml:11: insufficient cooldown in Dependabot updates
```

With no cooldown, Dependabot opens a PR the moment a version ships. That is the window where a compromised release is still unreported, and it is the window a supply-chain attack depends on. Both groups now set `default-days: 7`.

## Why I missed it locally

I ran zizmor against `.github/workflows/`. CI collects `dependabot.yml` too, so the local run was clean on a finding CI fails. CONTRIBUTING.md gave contributors that same wrong command, so the second commit corrects it to `--collect all -- .` and explains why the scope matters.

## Verification

`uvx zizmor@1.29.0 --no-online-audits --persona pedantic --min-severity low --collect all -- .` reports no findings across all three files (`dependabot.yml`, `ci.yml`, `security.yml`).

CI's run adds online audits, which this local invocation cannot cover; that gap is why the job runs in CI at all.