### PR TITLE
Regenerate bun.lock on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,52 @@
+name: Dependabot lockfile
+
+# Dependabot updates package.json but cannot regenerate bun.lock, so every bun
+# dependency PR fails `bun install --frozen-lockfile` in CI. This regenerates
+# the lockfile and pushes it back to the PR branch.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-lockfile-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync-lockfile:
+    name: Regenerate bun.lock
+    # Only for Dependabot's own PRs. This job pushes a commit, so it must never
+    # run on a branch an outside contributor controls. Gated on the PR author
+    # rather than github.actor, which is spoofable (zizmor bot-conditions).
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # commits the regenerated bun.lock back to the PR branch
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.head_ref }}
+          # This job pushes, so it is the one checkout that keeps its token.
+          persist-credentials: true
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.14"
+      - name: Regenerate lockfile
+        working-directory: plugins/pstack/skills/poteto-mode/scripts
+        run: bun install
+      - name: Commit if the lockfile moved
+        env:
+          # github.head_ref is attacker-controllable in general; quoting it via
+          # env keeps it out of the shell command line.
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if git diff --quiet -- plugins/pstack/skills/poteto-mode/scripts/bun.lock; then
+            echo "ok: bun.lock already matches package.json"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add plugins/pstack/skills/poteto-mode/scripts/bun.lock
+          git commit -m "deps: regenerate bun.lock"
+          git push origin "HEAD:$HEAD_REF"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,14 @@ uvx zizmor@1.29.0 --persona pedantic --min-severity low --collect all -- .
 - **A version bump in only some manifests.** The version string is duplicated in `plugins/pstack/.claude-plugin/plugin.json`, `plugins/pstack/.codex-plugin/plugin.json`, and `.claude-plugin/marketplace.json`. All three move together.
 - **An action pinned to a tag.** Use the full 40-character commit SHA with a version comment. A mutable tag can be force-pushed into our runners.
 
+## Dependency updates
+
+Dependabot updates `package.json` but cannot regenerate `bun.lock`, so a bun dependency PR arrives with the two out of sync and fails `bun install --frozen-lockfile`. The `Dependabot lockfile` workflow regenerates the lockfile and pushes it back to the PR branch, so those PRs go green on their own.
+
+It only runs for PRs authored by `dependabot[bot]`, checked via `github.event.pull_request.user.login` rather than `github.actor`, which is spoofable. It is the one job in this repo with `contents: write`.
+
+If you bump a dependency by hand, run `bun install` and commit the resulting `bun.lock` in the same change.
+
 ## Releasing
 
 Plugin auto-update installs **by version number**, not by tracking `main`. A skill fix merged without a version bump is inert on every installed copy, because the updater sees the same version it already has and does nothing.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ Two workflows run on every pull request and push to `main`.
 
 `ci.yml` runs three jobs: the static plugin invariants (`tests/skill-collision-repro.sh` under `SKIP_BEHAVIORAL=1`, since the behavioral leg needs the `claude` CLI and API access), the vendored bun tooling (`bun install --frozen-lockfile`, `bun run typecheck`, `bun test orch watch-pr`), and `shellcheck` over every `.sh` file.
 
-`security.yml` runs `osv-scanner` against the lockfiles and fails the build if no lockfile was found, because an empty scan reads exactly like a clean one. It also rejects any action reference not pinned to a full 40-character commit SHA. It runs weekly on top of the per-PR trigger, so a CVE published after a merge still surfaces. Dependabot keeps the pinned SHAs and the bun dependencies current.
+`security.yml` runs `osv-scanner` against the lockfiles and fails the build if no lockfile was found, because an empty scan reads exactly like a clean one. It also rejects any action reference not pinned to a full 40-character commit SHA. It runs weekly on top of the per-PR trigger, so a CVE published after a merge still surfaces. `zizmor` audits the workflows themselves for template injection, over-broad permissions, and credential persistence.
+
+Dependabot keeps the pinned SHAs and the bun dependencies current, on a 7-day cooldown so a compromised release has time to be reported before a PR opens. Because Dependabot cannot regenerate `bun.lock`, `dependabot-lockfile.yml` does it for its PRs and pushes the result back to the branch.
 
 Before a release, run the full `tests/skill-collision-repro.sh` locally (without `SKIP_BEHAVIORAL`) to exercise the behavioral leg CI cannot.
 


### PR DESCRIPTION
Fixes the class of failure blocking #32.

## The problem

Dependabot updates `package.json` but cannot regenerate `bun.lock`. The two arrive out of sync, so `bun install --frozen-lockfile` rejects the PR:

```
error: lockfile had changes, but lockfile is frozen
```

#32 (commander 14 to 15) is the first instance. Without a fix, every future bun dependency PR fails identically, and the choice each time is to regenerate by hand or ignore the update.

## The fix

`dependabot-lockfile.yml` runs `bun install` on Dependabot PR branches and pushes the regenerated lockfile back, so those PRs go green without intervention.

## Security

This job has `contents: write` and pushes a commit, so the gate matters. zizmor flagged my first attempt: `github.actor == 'dependabot[bot]'` is spoofable (`bot-conditions`, high severity). It now gates on `github.event.pull_request.user.login`, which is not. `github.head_ref` reaches the shell through `env:` rather than direct interpolation.

Every other checkout in the repo keeps `persist-credentials: false`. This is the one job that needs its token, and that is commented in place.

## Verification

- `zizmor --persona pedantic --min-severity low --collect all`: no findings across all four workflow files, after fixing the two it initially raised.
- Plugin invariants and shellcheck: clean.
- Commander 15 itself was verified separately against a regenerated lockfile: frozen install succeeds, typecheck clean, 52/52 tests pass. So #32 is a real, safe update once the lockfile is in sync.

The workflow's own behavior (pushing to a Dependabot branch) cannot be verified until a Dependabot PR runs against it. #32 will be that test.
