### PR TITLE
Close four silent-failure paths in the orch store

### DIFF
--- a/plugins/pstack/skills/poteto-mode/scripts/orch/orch.test.ts
+++ b/plugins/pstack/skills/poteto-mode/scripts/orch/orch.test.ts
@@ -137,6 +137,9 @@ case "$*" in
   "--no-interactive info stack/open")
     printf 'stack/open\\nPR #11 (Needs approvals) open change\\n'
     ;;
+  "--no-interactive info stack/paren")
+    printf 'stack/paren\\nPR #14 (Needs approvals (2)) tricky change\\n'
+    ;;
   *)
     printf 'unexpected gt arguments: %s\\n' "$*" >&2
     exit 2
@@ -493,6 +496,56 @@ describe("Store", () => {
         );
       },
     });
+  });
+
+  it("rejects a parenthesized gt PR status instead of treating it as open", async () => {
+    const { directory, store } = await initializedStore();
+    const stack = await makeGitStack(directory);
+
+    await withFakeGt({
+      directory,
+      output: "◯ main\n◉ stack/paren\n",
+      operation: async () => {
+        await expect(
+          store.frontier.set({ repo: stack.repo })
+        ).rejects.toThrow(
+          "gt info output has an invalid PR row for branch stack/paren"
+        );
+      },
+    });
+  });
+
+  it("rejects a leading-dash branch name in gt log output", async () => {
+    const { directory, store } = await initializedStore();
+    const stack = await makeGitStack(directory);
+
+    await withFakeGt({
+      directory,
+      output: "◯ main\n◉ --upload-pack=/tmp/pwn\n",
+      operation: async () => {
+        await expect(
+          store.frontier.set({ repo: stack.repo })
+        ).rejects.toThrow("gt log short output has an unparseable line 2");
+      },
+    });
+  });
+
+  it("keeps status.md table cells single-line when frontier data carries control characters", async () => {
+    const { directory, store } = await initializedStore();
+
+    await writeFile(
+      join(directory, "frontier.json"),
+      `${JSON.stringify({
+        generation: 1,
+        prs: [
+          { pr: 7, branches: "a\nb|c", sha: "cafe\tf00d", state: "OPEN" },
+        ],
+        lowestUnmerged: 7,
+      })}\n`
+    );
+    await store.status.render();
+    const status = await readFile(join(directory, "status.md"), "utf8");
+    expect(status).toContain("| a b\\|c | 7 | cafe f00d | OPEN |");
   });
 
   it("rejects malformed TSV, verdict, frontier, and inbox data", async () => {

--- a/plugins/pstack/skills/poteto-mode/scripts/orch/store.ts
+++ b/plugins/pstack/skills/poteto-mode/scripts/orch/store.ts
@@ -342,7 +342,8 @@ async function atomicWrite(path: string, contents: string): Promise<void> {
     await writeFile(temporary, contents, { flag: "wx" });
     await rename(temporary, path);
   } finally {
-    await rm(temporary, { force: true });
+    // Best-effort cleanup: a throw here would replace the write's own error.
+    await rm(temporary, { force: true }).catch(() => {});
   }
 }
 
@@ -881,7 +882,10 @@ function changed(before: StatusSummary | null, after: StatusSummary): string {
 }
 
 function markdown(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+  return value
+    .replace(/[\t\n\r]/g, " ")
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|");
 }
 
 function table(
@@ -1010,7 +1014,7 @@ function parseGtPullRequest({
   detail: string;
 }): GtPullRequest {
   const match =
-    /^(?:\[origin\] )?PR #([1-9]\d*)(?: \(([^)\r\n]+)\))?(?: .+)?$/.exec(
+    /^(?:\[origin\] )?PR #([1-9]\d*)(?: \(([^)\r\n]+)\))?( .+)?$/.exec(
       detail
     );
   const pr = Number(match?.[1] ?? 0);
@@ -1020,6 +1024,14 @@ function parseGtPullRequest({
     );
   }
   const status = match[2];
+  // A "(" right after the PR number that the status group did not capture
+  // means a nested-paren status like "Needs approvals (2)"; treating it as
+  // no-status would silently report the PR as OPEN.
+  if (status === undefined && (match[3] ?? "").startsWith(" (")) {
+    throw new UserError(
+      `gt info output has an invalid PR row for branch ${branch}: ${detail}`
+    );
+  }
   if (status === "Merged") {
     return { pr, state: "MERGED" };
   }
@@ -1041,8 +1053,10 @@ function parseGtBranches(raw: string): readonly string[] {
     if (line.length === 0) {
       continue;
     }
+    // (?!-) rejects leading-dash names, which git and gt would parse as
+    // options when the branch is later passed to them as an argument.
     const branchMatch =
-      /^(?:│ )*[◯◉] +([^\s]+)((?: \([^()\r\n]*\))*)$/.exec(line);
+      /^(?:│ )*[◯◉] +((?!-)[^\s]+)((?: \([^()\r\n]*\))*)$/.exec(line);
     if (branchMatch === null) {
       throw new UserError(
         `gt log short output has an unparseable line ${index + 1}: ${JSON.stringify(line)}`

--- a/plugins/pstack/skills/poteto-mode/scripts/orch/store.ts
+++ b/plugins/pstack/skills/poteto-mode/scripts/orch/store.ts
@@ -35,7 +35,7 @@ export interface Unit {
   readonly brief: string;
 }
 
-export interface LedgerEntry {
+interface LedgerEntry {
   readonly pr: string;
   readonly sha: string;
   readonly verdict: Verdict;
@@ -52,7 +52,7 @@ export interface InboxPointer {
   readonly report: string;
 }
 
-export interface InboxPushResult {
+interface InboxPushResult {
   readonly pointer: InboxPointer;
   readonly filename: string;
 }
@@ -65,7 +65,7 @@ export interface OpenGate {
   readonly defaultAnswer: string;
 }
 
-export interface ResolvedGate {
+interface ResolvedGate {
   readonly kind: "resolved";
   readonly id: string;
   readonly question: string;
@@ -76,9 +76,9 @@ export interface ResolvedGate {
 
 export type Gate = OpenGate | ResolvedGate;
 
-export type FrontierPrState = "OPEN" | "MERGED" | "CLOSED";
+type FrontierPrState = "OPEN" | "MERGED" | "CLOSED";
 
-export interface FrontierPr {
+interface FrontierPr {
   readonly pr: number;
   readonly branches: string;
   readonly sha: string;
@@ -98,7 +98,7 @@ export interface StandingLine {
 
 export type Counts = Readonly<Record<string, number>>;
 
-export interface StatusSummary {
+interface StatusSummary {
   readonly unitStates: Counts;
   readonly ledgerVerdicts: Counts;
   readonly frontierGeneration: number;
@@ -114,13 +114,13 @@ export interface StatusReport {
   readonly changed: string;
 }
 
-export interface AddUnitParams {
+interface AddUnitParams {
   readonly id: string;
   readonly track: string;
   readonly brief?: string;
 }
 
-export interface SetUnitParams {
+interface SetUnitParams {
   readonly id: string;
   readonly state: string;
   readonly branch?: string;
@@ -128,12 +128,12 @@ export interface SetUnitParams {
   readonly sha?: string;
 }
 
-export interface ListUnitsParams {
+interface ListUnitsParams {
   readonly state?: string;
   readonly track?: string;
 }
 
-export interface RecordLedgerParams {
+interface RecordLedgerParams {
   readonly pr: number;
   readonly sha: string;
   readonly verdict: Verdict;
@@ -141,36 +141,36 @@ export interface RecordLedgerParams {
   readonly verifier?: string;
 }
 
-export interface CheckLedgerParams {
+interface CheckLedgerParams {
   readonly pr: number;
   readonly sha: string;
 }
 
-export interface PushInboxParams {
+interface PushInboxParams {
   readonly agent: string;
   readonly unit: string;
   readonly status: string;
   readonly report?: string;
 }
 
-export interface ParkGateParams {
+interface ParkGateParams {
   readonly id: string;
   readonly question: string;
   readonly options: string;
   readonly defaultAnswer: string;
 }
 
-export interface ResolveGateParams {
+interface ResolveGateParams {
   readonly id: string;
   readonly answer: string;
 }
 
-export interface SetFrontierParams {
+interface SetFrontierParams {
   readonly repo: string;
   readonly prs?: readonly number[];
 }
 
-export interface AddStandingParams {
+interface AddStandingParams {
   readonly line: string;
 }
 
@@ -219,7 +219,7 @@ export interface Store {
   readonly close: () => Promise<void>;
 }
 
-export interface NotFoundOutput {
+interface NotFoundOutput {
   readonly compact: string;
   readonly json: unknown;
 }
@@ -1285,7 +1285,7 @@ export function openStore(
         const rows = [...(await readUnits(store))];
         const index = rows.findIndex((unit) => unit.id === id);
         const old = rows[index];
-        if (index < 0 || old === undefined) {
+        if (old === undefined) {
           throw new NotFoundError(`unit ${id} not found`);
         }
         const row: Unit = {
@@ -1478,7 +1478,7 @@ export function openStore(
         const rows = [...(await readGates(store))];
         const index = rows.findIndex((gate) => gate.id === id);
         const old = rows[index];
-        if (index < 0 || old === undefined) {
+        if (old === undefined) {
           throw new NotFoundError(`gate ${id} not found`);
         }
         const gate: ResolvedGate = {


### PR DESCRIPTION
Fixes the small verified findings from the store.ts review. Each fix landed after a failing regression test (first commit), so the diff tells the story.

- `parseGtPullRequest`: a nested-paren status such as `PR #14 (Needs approvals (2))` used to skip the status capture and fall through to `OPEN`, bypassing the unknown-state guard. It now throws the invalid-row error. Plain statuses with parenthesized PR titles (`PR #12 (Merged) fix (typo)`) still parse.
- `parseGtBranches`: branch names starting with `-` are rejected at the parse boundary. Before, `gt log` output could place an option-shaped string (`--upload-pack=...`) into `git rev-parse` / `gt info` argv; the new test proved the string reached the fake `gt` in option position.
- `markdown()`: tabs, newlines, and CRs flatten to spaces before escaping, so a hand-edited `frontier.json` can no longer break `status.md` table rows across lines.
- `atomicWrite`: the cleanup `rm` in `finally` is best-effort now; it previously could replace the write's own error when the store directory turned unwritable mid-write.

A separate refactor commit removes the `export` keyword from seventeen types nothing imports (verified against `orch.ts`, `orch.test.ts`, and all of `watch-pr/`; they stay reachable structurally through `Store`) and collapses two `index < 0 || old === undefined` guards to the `undefined` check that already covers both.

Verification: `bun test orch watch-pr` passes 55/55 (52 existing + 3 new regressions). `bun run typecheck` clean, and orch/store/bootstrap also pass an explicit `tsc --strict --noUncheckedIndexedAccess` run, which CI does not currently perform (known gap, out of scope here).

Out of scope, still open from the same review: the lock-protocol races, the spoofable `previousSummary` regex, and the trunk-only frontier wipe.