### PR TITLE
Lint the extensionless hook scripts and validate hooks.json targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # Select by extension OR shebang. The hook scripts are deliberately
+      # extensionless (Claude Code's Windows auto-detection prepends "bash" to
+      # any command containing ".sh"), so an extension-only glob skipped the
+      # one script that runs at every user's session start.
       - name: Run shellcheck
         run: |
           shellcheck --version
-          find . -path ./.git -prune -o -name '*.sh' -print0 \
-            | xargs -0 shellcheck --severity=warning
+          {
+            find . -path ./.git -prune -o -path '*/node_modules' -prune -o -name '*.sh' -print
+            grep -rlE --exclude-dir=.git --exclude-dir=node_modules '^#!/(usr/bin/env )?(ba)?sh' .
+          } | sed 's#^\./##' | sort -u | tee /dev/stderr | xargs shellcheck --severity=warning

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,8 @@ uvx zizmor@1.29.0 --persona pedantic --min-severity low --collect all -- .
 
 - **A `plugins/pstack/commands/` directory.** Claude Code renders commands and user-invocable skills in the same slash menu, so a trampoline paired with its skill duplicates every `/pstack:<name>` row ([#22](https://github.com/michael-denyer/pstack-claude/issues/22)). Codex stubs live in `plugins/pstack/.codex-plugin/prompts/`. An upstream sync will try to reintroduce `commands/`; move any new stubs across.
 - **`disable-model-invocation` in a skill's frontmatter.** On a skill it makes the Skill tool refuse the invocation outright, which breaks the SessionStart mandate. The `principle-*` leaves use `user-invocable: false` instead.
-- **Stale generated output.** The `Generated files current` job reruns `bun tools/generate.mjs` and fails on any diff. Editing `VERSION` without regenerating, hand-editing a manifest's `version` field, or bumping without a matching `CHANGES.md` heading all land here.
+- **Stale generated output.** The `Generated files current` job reruns `bun tools/generate.mjs` and fails on any diff. Editing `VERSION` without regenerating, hand-editing a manifest's `version` field, or bumping without a matching `CHANGES.md` heading all land here. The same run validates `hooks/hooks.json`: every command must point at an existing, executable script under the plugin.
+- **A shell script that fails shellcheck.** Scripts are selected by `.sh` extension or by shebang, so the extensionless hook scripts (`hooks/session-start`) are linted too.
 - **An action pinned to a tag.** Use the full 40-character commit SHA with a version comment. A mutable tag can be force-pushed into our runners.
 
 ## Dependency updates

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Verified on a live Codex session installed via the symlinks: the user-facing ski
 
 Two workflows run on every pull request and push to `main`.
 
-`ci.yml` runs four jobs: the static plugin invariants (`tests/skill-collision-repro.sh` under `SKIP_BEHAVIORAL=1`, since the behavioral leg needs the `claude` CLI and API access), a generated-files check (`bun tools/generate.mjs` followed by `git diff --exit-code`, so a `VERSION` bump that skips regeneration or the `CHANGES.md` entry fails the build), the vendored bun tooling (`bun install --frozen-lockfile`, `bun run typecheck`, `bun test orch watch-pr`), and `shellcheck` over every `.sh` file.
+`ci.yml` runs four jobs: the static plugin invariants (`tests/skill-collision-repro.sh` under `SKIP_BEHAVIORAL=1`, since the behavioral leg needs the `claude` CLI and API access), a generated-files check (`bun tools/generate.mjs` followed by `git diff --exit-code`, so a `VERSION` bump that skips regeneration or the `CHANGES.md` entry fails the build), the vendored bun tooling (`bun install --frozen-lockfile`, `bun run typecheck`, `bun test orch watch-pr`), and `shellcheck` over every shell script, selected by `.sh` extension or by shebang so the extensionless hook scripts are covered.
 
 `security.yml` runs `osv-scanner` against the lockfiles and fails the build if no lockfile was found, because an empty scan reads exactly like a clean one. It also rejects any action reference not pinned to a full 40-character commit SHA. It runs weekly on top of the per-PR trigger, so a CVE published after a merge still surfaces. `zizmor` audits the workflows themselves for template injection, over-broad permissions, and credential persistence.
 

--- a/tools/generate.mjs
+++ b/tools/generate.mjs
@@ -271,6 +271,32 @@ export function renderReadmeTable(readme, skills) {
   return lines.join("\n");
 }
 
+// hooks.json names commands as "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd <script>";
+// both the runner and the named script must exist in the plugin and be
+// executable, or the SessionStart hook fails silently for every user.
+export function validateHooks(hooksJson, { statOf }) {
+  const problems = [];
+  for (const [event, groups] of Object.entries(JSON.parse(hooksJson).hooks ?? {})) {
+    for (const group of groups) {
+      for (const hook of group.hooks ?? []) {
+        const m = hook.command?.match(/\$\{CLAUDE_PLUGIN_ROOT\}\/([^"\s]+)"?(?:\s+(\S+))?/);
+        if (!m) {
+          problems.push(`${event}: command does not reference \${CLAUDE_PLUGIN_ROOT}: ${hook.command}`);
+          continue;
+        }
+        const targets = [m[1]];
+        if (m[1].endsWith("run-hook.cmd") && m[2]) targets.push(`hooks/${m[2]}`);
+        for (const t of targets) {
+          const st = statOf(t);
+          if (!st) problems.push(`${event}: ${t} does not exist`);
+          else if (!(st.mode & 0o111)) problems.push(`${event}: ${t} is not executable`);
+        }
+      }
+    }
+  }
+  if (problems.length) throw new Error(`hooks.json:\n  ${problems.join("\n  ")}`);
+}
+
 function main() {
   const version = readFileSync(join(repo, "VERSION"), "utf8").trim();
   if (!/^\d+\.\d+\.\d+$/.test(version)) {
@@ -390,6 +416,12 @@ function main() {
     pathExists: (p) => existsSync(join(repo, p)),
   });
   console.log("ok: .agents/plugins/marketplace.json names the plugin and points at a real path");
+
+  const pluginRoot = join(repo, "plugins/pstack");
+  validateHooks(readFileSync(join(pluginRoot, "hooks/hooks.json"), "utf8"), {
+    statOf: (rel) => (existsSync(join(pluginRoot, rel)) ? statSync(join(pluginRoot, rel)) : null),
+  });
+  console.log("ok: hooks.json commands point at existing, executable scripts");
 }
 
 try {


### PR DESCRIPTION
Follow-up from the architecture review (candidate 6).

The `shellcheck` CI job selected files by `.sh` extension. The hook scripts are deliberately extensionless (Claude Code's Windows auto-detection prepends `bash` to any command containing `.sh`, per the comment in `run-hook.cmd`), so `hooks/session-start`, the one script that runs at every user's session start, was the one script never linted.

- The shellcheck step now selects by `.sh` extension or by shebang (`#!/usr/bin/env bash`, `#!/bin/sh`, and friends), excluding `.git` and `node_modules`, and prints the selected list to the job log. Four files are selected today; `hooks/session-start` is the new one and is clean.
- `tools/generate.mjs` validates `hooks/hooks.json`: every command must reference `${CLAUDE_PLUGIN_ROOT}`, and both the runner and the script it names must exist under the plugin and be executable. A hook that fails here fails silently for every user at session start, which is the worst place to find out.
- README's CI section and CONTRIBUTING's "things that will fail CI" describe both.

Left alone: `hooks/session-start` itself. The review flagged it as a pass-through (`exec cat` of a sibling file) but `run-hook.cmd` is upstream-derived and generic by design; collapsing the one-liner would special-case the runner for a saving of seven lines.

Verified: the CI shellcheck pipeline run locally selects exactly `plugins/pstack/hooks/session-start`, `worktree-audit.sh`, `log.sh`, and `tests/skill-collision-repro.sh` and passes. The generator reports the hooks check `ok` on the real tree; in a scratch copy, a missing `session-start` fails with "does not exist" and a `chmod -x` copy fails with "is not executable". `zizmor --persona pedantic --collect all` reports no findings.