### PR TITLE
Update Codex model examples to Astra and GPT-5.6

### DIFF
--- a/plugins/pstack/models.json
+++ b/plugins/pstack/models.json
@@ -31,7 +31,7 @@
     { "role": "interrogate reviewers", "models": ["claude-opus-5", "claude-fable-5", "claude-sonnet-5"], "skill": "interrogate" }
   ],
   "codex": {
-    "singleRoleExample": "gpt-5.6-sol",
-    "panelQuad": ["gpt-5.6-sol", "gpt-5.5", "gpt-5.4", "gpt-5.6-luna"]
+    "singleRoleExample": "gpt-6-astra",
+    "panelQuad": ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
   }
 }

--- a/plugins/pstack/skills/poteto-mode/references/codex-tools.md
+++ b/plugins/pstack/skills/poteto-mode/references/codex-tools.md
@@ -43,8 +43,8 @@ poteto-mode's Subagents section sets Claude-specific defaults (`subagent_type: "
 
 Skills name Claude defaults (a single-role default for code/prose/judgment plus a diverse-model panel for diverse-model panels; each model-consuming skill lists its own in a Models section). These slugs do not resolve on Codex. Substitute your configured Codex models:
 
-- Single-model roles: your primary Codex model (for example `gpt-5.6-sol`).
-- Diverse-model panels (`arena`, `architect`, `interrogate`, `how` critics, `reflect`): the adversarial signal comes from model diversity, so use the distinct Codex models available to you. A good default quad on ChatGPT is `gpt-5.6-sol`, `gpt-5.5`, `gpt-5.4`, `gpt-5.6-luna`. If only one model family is reachable, vary reasoning effort and note in the verdict that diversity was reduced.
+- Single-model roles: your primary Codex model (for example `gpt-6-astra`).
+- Diverse-model panels (`arena`, `architect`, `interrogate`, `how` critics, `reflect`): the adversarial signal comes from model diversity, so use the distinct Codex models available to you. A good default quad on ChatGPT is `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`. If only one model family is reachable, vary reasoning effort and note in the verdict that diversity was reduced.
 
 `/setup-pstack` writes the configured model list. On Codex, set it to your Codex model slugs.
 


### PR DESCRIPTION
Use `gpt-6-astra` as the Codex single-model example and Astra, Sol, Terra, and Luna as the suggested panel. This replaces the older GPT-5.5 and GPT-5.4 panel entries and regenerates the model guidance from `plugins/pstack/models.json`.

Validation: all 26 repository tests pass on a copy of tracked files; the generator succeeds without further changes; `git diff --check` passes. Running validation directly in the working directory encounters pre-existing broken documentation links in the installed `node_modules/commander` package.
